### PR TITLE
Interface reorg plus Sonar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,23 @@ To use the library in your own Maven project, declare the following dependencies
 
 1) If you only need the IK algorithm and do not need any visualisation:
 
+```xml
     <dependency>
       <groupId>au.edu.federation.caliko</groupId>
       <artifactId>caliko</artifactId>
       <version>1.3.2</version>
     </dependency> 
+```
 
-2) If you need the IK algorirthm and the visualisation:
+2) If you need the IK algorithm and the visualisation:
 
+```xml
     <dependency>
       <groupId>au.edu.federation.caliko.visualisation</groupId>
       <artifactId>caliko-visualisation</artifactId>
       <version>1.3.2</version>
     </dependency> 
+```
 
 ## Demo controls
 

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo/Application.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo/Application.java
@@ -27,8 +27,6 @@ public class Application
 	// State tracking variables
 	static boolean use3dDemo           = false;
 	static int     demoNumber          = 1;
-	static int     num2dDemos          = 8;
-	static int     num3dDemos          = 12;
 	static boolean fixedBaseMode       = true;
 	static boolean rotateBasesMode     = false;
 	static boolean drawLines           = true;

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo/OpenGLWindow.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo/OpenGLWindow.java
@@ -57,10 +57,8 @@ public class OpenGLWindow
     public OpenGLWindow(int windowWidth, int windowHeight, float vertFoVDegs, float zNear, float zFar, float orthoExtent)
     {
     	// Set properties and create the projection matrix
-    	if (windowWidth  <= 0) { windowWidth  = 1; }
-		if (windowHeight <= 0) { windowHeight = 1; } 
-    	mWindowWidth  = windowWidth;
-    	mWindowHeight = windowHeight;
+    	mWindowWidth  = windowWidth <= 0 ? 1 : windowWidth;
+    	mWindowHeight = windowHeight <= 0 ? 1 : windowHeight;
     	mAspectRatio  = (float)mWindowWidth / (float)mWindowHeight; 
     	
     	mVertFoVDegs = vertFoVDegs;
@@ -358,7 +356,7 @@ public class OpenGLWindow
 				if (Application.use3dDemo)
 				{	
 					// Immediately set the cursor position to the centre of the screen so our view doesn't "jump" on first cursor position change
-					glfwSetCursorPos(windowId, (double)(mWindowWidth / 2), (double)(mWindowHeight / 2.) );
+					glfwSetCursorPos(windowId, ((double)mWindowWidth / 2), ((double)mWindowHeight / 2) );
 					
 					switch (action)
 					{

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo/OpenGLWindow.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo/OpenGLWindow.java
@@ -8,6 +8,8 @@ import org.lwjgl.glfw.GLFWVidMode;
 import org.lwjgl.glfw.GLFWWindowSizeCallback;
 import org.lwjgl.opengl.GL;
 
+import au.edu.federation.caliko.demo2d.CalikoDemoStructure2DFactory.CalikoDemoStructure2DEnum;
+import au.edu.federation.caliko.demo3d.CalikoDemoStructure3DFactory.CalikoDemoStructure3DEnum;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
 import au.edu.federation.utils.Vec2f;
@@ -200,11 +202,11 @@ public class OpenGLWindow
 	            	case GLFW_KEY_RIGHT:						
 	            		if (Application.use3dDemo)
 	            		{
-	            			if (Application.demoNumber < Application.num3dDemos) { Application.demoNumber++; }
+	            			if (Application.demoNumber < CalikoDemoStructure3DEnum.values().length) { Application.demoNumber++; }
 	            		}
 	            		else // 2D Demo mode
 	            		{
-	            			if (Application.demoNumber < Application.num2dDemos) { Application.demoNumber++; }
+	            			if (Application.demoNumber < CalikoDemoStructure2DEnum.values().length) { Application.demoNumber++; }
 	            		}
 						Application.demo.setup(Application.demoNumber);	            		
 						break;	

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/CalikoDemoStructure2DFactory.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/CalikoDemoStructure2DFactory.java
@@ -5,7 +5,7 @@ package au.edu.federation.caliko.demo2d;
  */
 public class CalikoDemoStructure2DFactory {
 	
-	public static CalikoDemoStructure2D makeDemoStructure2D(int demoNumber) throws Exception {
+	public static CalikoDemoStructure2D makeDemoStructure2D(int demoNumber) throws ReflectiveOperationException {
 		CalikoDemoStructure2DEnum aDemo = findEnumForDemoNumber(demoNumber);
 		if(aDemo !=null ) {
 			return aDemo.getClazz().newInstance();
@@ -22,24 +22,22 @@ public class CalikoDemoStructure2DFactory {
 		return null;
 	}	
 	
-	private enum CalikoDemoStructure2DEnum {
+	public enum CalikoDemoStructure2DEnum {
 		
-		FIXEDBASE_ABSOLUTEBASEBONEJOINT_CONSTRAINTS(FixedBaseAbsoluteBaseBoneJointConstraints.class,1),
-		FIXEDBASE_UNCONSTRAINEDBASEBONE_UNCONSTRAINEDBONES(FixedBaseUnconstrainedBaseBaseMultipleUnconstrainedBones.class, 2),
-		FIXEDBASE_UNCONSTRAINEDBASEBONE_CONSTRAINEDBONES(FixedBaseUnconstrainedBaseBoneMultipleConstrainedBones.class, 3),
-		MULTIPLECONNECTEDCHAINS_NOBASEBONE_CONSTRAINTS(MultipleConnectedChainsNoBaseBoneConstraints.class, 4),
-		MULTIPLECONNECTEDCHAINS_LOCALRELATIVEBASEBONE_CONSTRAINTS(MultipleConnectedChainsLocalRelativeBaseBoneConstraints.class, 5),
-		MULTIPLECONNECTEDCHAINS_LOCALABSOLUTEBASEBONE_CONSTRAINTS(MultipleConnectedChainsLocalAbsoluteBaseBoneConstraints.class, 6),
-		VARYINGOFFSET_FIXEDCHAINS_WITHEMBEDDED_TARGETS(VaryingOffsetFixedChainsWithEmbeddedTargets.class, 7),
-		MULTIPLENESTEDCHAINS_SEMIRANDOM(MultipleNestedChainsSemiRandom.class, 8);
+		FIXEDBASE_ABSOLUTEBASEBONEJOINT_CONSTRAINTS(FixedBaseAbsoluteBaseBoneJointConstraints.class),
+		FIXEDBASE_UNCONSTRAINEDBASEBONE_UNCONSTRAINEDBONES(FixedBaseUnconstrainedBaseBaseMultipleUnconstrainedBones.class),
+		FIXEDBASE_UNCONSTRAINEDBASEBONE_CONSTRAINEDBONES(FixedBaseUnconstrainedBaseBoneMultipleConstrainedBones.class),
+		MULTIPLECONNECTEDCHAINS_NOBASEBONE_CONSTRAINTS(MultipleConnectedChainsNoBaseBoneConstraints.class),
+		MULTIPLECONNECTEDCHAINS_LOCALRELATIVEBASEBONE_CONSTRAINTS(MultipleConnectedChainsLocalRelativeBaseBoneConstraints.class),
+		MULTIPLECONNECTEDCHAINS_LOCALABSOLUTEBASEBONE_CONSTRAINTS(MultipleConnectedChainsLocalAbsoluteBaseBoneConstraints.class),
+		VARYINGOFFSET_FIXEDCHAINS_WITHEMBEDDED_TARGETS(VaryingOffsetFixedChainsWithEmbeddedTargets.class),
+		MULTIPLENESTEDCHAINS_SEMIRANDOM(MultipleNestedChainsSemiRandom.class);
 		
 		
 		Class<? extends CalikoDemoStructure2D> clazz;
-		int demoNumber;
 		
-		private <T extends CalikoDemoStructure2D> CalikoDemoStructure2DEnum(Class<T> clazz, int demoNumber) {
+		private <T extends CalikoDemoStructure2D> CalikoDemoStructure2DEnum(Class<T> clazz) {
 			this.clazz = clazz;
-			this.demoNumber = demoNumber;
 		}
 		
 		public Class<? extends CalikoDemoStructure2D> getClazz() {
@@ -47,7 +45,7 @@ public class CalikoDemoStructure2DFactory {
 		}
 		
 		public int getDemoNumber() {
-			return this.demoNumber;
+			return this.ordinal() + 1;
 		}
 		
 	}

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/FixedBaseUnconstrainedBaseBoneMultipleConstrainedBones.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/FixedBaseUnconstrainedBaseBoneMultipleConstrainedBones.java
@@ -30,7 +30,7 @@ public class FixedBaseUnconstrainedBaseBoneMultipleConstrainedBones extends Cali
 		for (int loop = 0; loop < numBones; loop++)
 		{
 			// Each bone added will be rotated 10 degrees further than the last
-			Vec2f rotatedUV = Vec2f.rotateDegs(defaultUV, loop * numBones);
+			Vec2f rotatedUV = Vec2f.rotateDegs(defaultUV, (float)loop * numBones);
 			
 			// Constrained
 			chain.addConsecutiveConstrainedBone(rotatedUV, boneLength, 60.0f, 60.0f);

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/MultipleConnectedChainsLocalAbsoluteBaseBoneConstraints.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/MultipleConnectedChainsLocalAbsoluteBaseBoneConstraints.java
@@ -1,9 +1,9 @@
 package au.edu.federation.caliko.demo2d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone2D;
 import au.edu.federation.caliko.FabrikChain2D;
 import au.edu.federation.caliko.FabrikChain2D.BaseboneConstraintType2D;
-import au.edu.federation.caliko.FabrikChain2D.BoneConnectionPoint2D;
 import au.edu.federation.caliko.FabrikStructure2D;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
@@ -64,7 +64,7 @@ public class MultipleConnectedChainsLocalAbsoluteBaseBoneConstraints extends Cal
 		leftChain.addConsecutiveConstrainedBone(LEFT, boneLength, 90.0f, 90.0f, Utils.MID_GREEN);
 								
 		// Add the chain to the structure, connecting at the end of bone 0 in chain 0
-		this.structure.addConnectedChain(leftChain, 0, 0, BoneConnectionPoint2D.END);
+		this.structure.connectChain(leftChain, 0, 0, BoneConnectionPoint.END);
 		
 		// ----- Right branch chain -----				
 		// Create the base bone
@@ -86,7 +86,7 @@ public class MultipleConnectedChainsLocalAbsoluteBaseBoneConstraints extends Cal
 		rightChain.addConsecutiveConstrainedBone(RIGHT, boneLength, 90.0f, 90.0f, Utils.GREY);
 		
 		// Add the chain to the structure, connecting at the end of bone 1 in chain 0
-		this.structure.addConnectedChain(rightChain, 0, 1, BoneConnectionPoint2D.END);
+		this.structure.connectChain(rightChain, 0, 1, BoneConnectionPoint.END);
 	}
 	
 	@Override

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/MultipleConnectedChainsLocalRelativeBaseBoneConstraints.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/MultipleConnectedChainsLocalRelativeBaseBoneConstraints.java
@@ -1,9 +1,9 @@
 package au.edu.federation.caliko.demo2d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone2D;
 import au.edu.federation.caliko.FabrikChain2D;
 import au.edu.federation.caliko.FabrikChain2D.BaseboneConstraintType2D;
-import au.edu.federation.caliko.FabrikChain2D.BoneConnectionPoint2D;
 import au.edu.federation.caliko.FabrikStructure2D;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
@@ -57,7 +57,7 @@ public class MultipleConnectedChainsLocalRelativeBaseBoneConstraints extends Cal
 		leftChain.addConsecutiveConstrainedBone(LEFT, boneLength, 60.0f, 60.0f, Utils.MID_GREEN);
 				
 		// Params: The chain to add to the structure, which chain it links to, which bone in that chain it links to
-		this.structure.addConnectedChain(leftChain, 0, 0, BoneConnectionPoint2D.END);
+		this.structure.connectChain(leftChain, 0, 0, BoneConnectionPoint.END);
 		
 		// ----- Right branch chain -----				
 		// Create the base bone
@@ -78,7 +78,7 @@ public class MultipleConnectedChainsLocalRelativeBaseBoneConstraints extends Cal
 		rightChain.addConsecutiveConstrainedBone(RIGHT, boneLength, 15.0f, 15.0f, Utils.GREY);
 		
 		// Add the chain to the structure, connecting at the end of bone 1 in chain 0
-		this.structure.addConnectedChain(rightChain, 0, 1, BoneConnectionPoint2D.END);
+		this.structure.connectChain(rightChain, 0, 1, BoneConnectionPoint.END);
 	}
 	
 	@Override

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/MultipleConnectedChainsNoBaseBoneConstraints.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/MultipleConnectedChainsNoBaseBoneConstraints.java
@@ -1,8 +1,8 @@
 package au.edu.federation.caliko.demo2d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone2D;
 import au.edu.federation.caliko.FabrikChain2D;
-import au.edu.federation.caliko.FabrikChain2D.BoneConnectionPoint2D;
 import au.edu.federation.caliko.FabrikStructure2D;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
@@ -50,7 +50,7 @@ public class MultipleConnectedChainsNoBaseBoneConstraints extends CalikoDemoStru
 		leftChain.addConsecutiveConstrainedBone(LEFT, boneLength, 90.0f, 90.0f, Utils.MID_GREEN);
 		
 		// Add the chain to the structure, connecting to the end of bone 0 in chain 0
-		this.structure.addConnectedChain(leftChain, 0, 0, BoneConnectionPoint2D.END);
+		this.structure.connectChain(leftChain, 0, 0, BoneConnectionPoint.END);
 		
 		// ----- Right branch chain -----
 					
@@ -68,7 +68,7 @@ public class MultipleConnectedChainsNoBaseBoneConstraints extends CalikoDemoStru
 		rightChain.addConsecutiveConstrainedBone(RIGHT, boneLength, 60.0f, 60.0f, Utils.GREY);
 		
 		// Add the chain to the structure, connecting to the end of bone 1 in chain 0
-		this.structure.addConnectedChain(rightChain, 0, 1, BoneConnectionPoint2D.END);
+		this.structure.connectChain(rightChain, 0, 1, BoneConnectionPoint.END);
 	}
 	
 	@Override

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/MultipleNestedChainsSemiRandom.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/MultipleNestedChainsSemiRandom.java
@@ -28,7 +28,7 @@ public class MultipleNestedChainsSemiRandom extends FixedTargetDemo {
 			tempChain.setBaseboneConstraintType(BaseboneConstraintType2D.LOCAL_RELATIVE);
 			tempChain.setBaseboneConstraintUV(UP);
 			
-			this.structure.addConnectedChain( createRandomChain(), Utils.randRange(0, chainsInStructure++), Utils.randRange(0, 5) );
+			this.structure.connectChain( createRandomChain(), Utils.randRange(0, chainsInStructure++), Utils.randRange(0, 5) );
 		}
 	}
 	

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/VaryingOffsetFixedChainsWithEmbeddedTargets.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo2d/VaryingOffsetFixedChainsWithEmbeddedTargets.java
@@ -1,9 +1,9 @@
 package au.edu.federation.caliko.demo2d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone2D;
 import au.edu.federation.caliko.FabrikChain2D;
 import au.edu.federation.caliko.FabrikChain2D.BaseboneConstraintType2D;
-import au.edu.federation.caliko.FabrikChain2D.BoneConnectionPoint2D;
 import au.edu.federation.caliko.FabrikStructure2D;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
@@ -68,7 +68,7 @@ public class VaryingOffsetFixedChainsWithEmbeddedTargets extends FixedTargetDemo
 		leftChain.setColour(Utils.MID_GREEN);
 		
 		// Add the left chain to the structure, connected to the start of bone 1 in chain 0
-		this.structure.addConnectedChain(leftChain, 0, 1, BoneConnectionPoint2D.START);
+		this.structure.connectChain(leftChain, 0, 1, BoneConnectionPoint.START);
 		
 		// ----- Right grey chain with embedded target -----
 		FabrikChain2D rightChain = new FabrikChain2D();				
@@ -90,7 +90,7 @@ public class VaryingOffsetFixedChainsWithEmbeddedTargets extends FixedTargetDemo
 		rightChain.setBaseboneRelativeConstraintUV(RIGHT);
 		
 		// Add the right chain to the structure, connected to the start of bone 2 in chain 0
-		this.structure.addConnectedChain(rightChain, 0, 2, BoneConnectionPoint2D.START);
+		this.structure.connectChain(rightChain, 0, 2, BoneConnectionPoint.START);
 	}
 	
 	@Override

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/CalikoDemoStructure3DFactory.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/CalikoDemoStructure3DFactory.java
@@ -5,7 +5,7 @@ package au.edu.federation.caliko.demo3d;
  */
 public final class CalikoDemoStructure3DFactory {
 	
-	public static CalikoDemoStructure3D makeDemoStructure3D(int demoNumber) throws Exception {
+	public static CalikoDemoStructure3D makeDemoStructure3D(int demoNumber) throws ReflectiveOperationException {
 		CalikoDemoStructure3DEnum aDemo = findEnumForDemoNumber(demoNumber);
 		if(aDemo !=null ) {
 			return aDemo.getClazz().newInstance();
@@ -22,27 +22,25 @@ public final class CalikoDemoStructure3DFactory {
 		return null;
 	}
 	
-	private enum CalikoDemoStructure3DEnum {
-		UNCONSTRAINED_BONES(UnconstrainedBones.class, 1),
-		ROTORBALL_CONSTRAINED_BONES(RotorBallJointConstrainedBones.class, 2),
-		ROTOR_CONSTRAINED_BASEBONES(RotorConstrainedBaseBones.class, 3),
-		FREELY_ROTATING_GLOBAL_HINGES(FreelyRotatingGlobalHinges.class, 4),
-		GLOBAL_HINGES_WITH_REFERENCE_AXIS_CONSTRAINTS(GlobalHingesWithReferenceAxisConstraints.class, 5),
-		FREELY_ROTATING_LOCAL_HINGES(FreelyRotatingLocalHinges.class, 6),
-		LOCAL_HINGES_WITH_REFERENCE_AXIS_CONSTRAINTS(LocalHingesWithReferenceAxisConstraints.class, 7),
-		CONNECTED_CHAINS(ConnectedChains.class, 8),
-		GLOBAL_ROTOR_CONSTRAINED_CONNECTED_CHAINS(GlobalRotorConstrainedConnectedChains.class, 9),
-		LOCAL_ROTOR_CONSTRAINED_CONNECTED_CHAINS(LocalRotorConstrainedConnectedChains.class, 10),
-		CONNECTED_CHAINS_WITH_FREELY_ROTATING_GLOBAL_HINGES_BASEBONE_CONSTRAINTS(ConnectedChainsWithFreelyRotatingGlobalHingesBaseboneConstraints.class, 11),
-		CONNECTED_CHAINS_WITH_EMBEDDED_TARGETS(ConnectedChainsWithEmbeddedTargets.class, 12);
+	public enum CalikoDemoStructure3DEnum {
+		UNCONSTRAINED_BONES(UnconstrainedBones.class),
+		ROTORBALL_CONSTRAINED_BONES(RotorBallJointConstrainedBones.class),
+		ROTOR_CONSTRAINED_BASEBONES(RotorConstrainedBaseBones.class),
+		FREELY_ROTATING_GLOBAL_HINGES(FreelyRotatingGlobalHinges.class),
+		GLOBAL_HINGES_WITH_REFERENCE_AXIS_CONSTRAINTS(GlobalHingesWithReferenceAxisConstraints.class),
+		FREELY_ROTATING_LOCAL_HINGES(FreelyRotatingLocalHinges.class),
+		LOCAL_HINGES_WITH_REFERENCE_AXIS_CONSTRAINTS(LocalHingesWithReferenceAxisConstraints.class),
+		CONNECTED_CHAINS(ConnectedChains.class),
+		GLOBAL_ROTOR_CONSTRAINED_CONNECTED_CHAINS(GlobalRotorConstrainedConnectedChains.class),
+		LOCAL_ROTOR_CONSTRAINED_CONNECTED_CHAINS(LocalRotorConstrainedConnectedChains.class),
+		CONNECTED_CHAINS_WITH_FREELY_ROTATING_GLOBAL_HINGES_BASEBONE_CONSTRAINTS(ConnectedChainsWithFreelyRotatingGlobalHingesBaseboneConstraints.class),
+		CONNECTED_CHAINS_WITH_EMBEDDED_TARGETS(ConnectedChainsWithEmbeddedTargets.class);
 		
 		
 		Class<? extends CalikoDemoStructure3D> clazz;
-		int demoNumber;
 		
-		private <T extends CalikoDemoStructure3D> CalikoDemoStructure3DEnum(Class<T> clazz, int demoNumber) {
+		private <T extends CalikoDemoStructure3D> CalikoDemoStructure3DEnum(Class<T> clazz) {
 			this.clazz = clazz;
-			this.demoNumber = demoNumber;
 		}
 		
 		public Class<? extends CalikoDemoStructure3D> getClazz() {
@@ -50,7 +48,7 @@ public final class CalikoDemoStructure3DFactory {
 		}
 		
 		public int getDemoNumber() {
-			return this.demoNumber;
+			return this.ordinal() + 1;
 		}
 	}
 

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/ConnectedChains.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/ConnectedChains.java
@@ -1,9 +1,9 @@
 package au.edu.federation.caliko.demo3d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone3D;
 import au.edu.federation.caliko.FabrikChain3D;
 import au.edu.federation.caliko.FabrikStructure3D;
-import au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D;
 import au.edu.federation.utils.Colour4f;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
@@ -48,17 +48,17 @@ public class ConnectedChains extends CalikoDemoStructure3D {
 		
 		// Set the colour of all bones in the chain in a single call, then connect it to the chain...
 		secondChain.setColour(Utils.RED);
-		this.structure.connectChain(secondChain, 0, 0, BoneConnectionPoint3D.START);
+		this.structure.connectChain(secondChain, 0, 0, BoneConnectionPoint.START);
 		
 		// ...we can keep adding the same chain at various points if we like, because the chain we
 		// connect is actually a clone of the one we provide, and not the original 'secondChain' argument.
 		secondChain.setColour(Utils.WHITE);
-		this.structure.connectChain(secondChain, 0, 2, BoneConnectionPoint3D.START);
+		this.structure.connectChain(secondChain, 0, 2, BoneConnectionPoint.START);
 		
 		// We can also set connect the chain to the end of a specified bone (this overrides the START/END 
 		// setting of the bone we connect to).
 		secondChain.setColour(Utils.BLUE);
-		this.structure.connectChain(secondChain, 0, 4, BoneConnectionPoint3D.END);
+		this.structure.connectChain(secondChain, 0, 4, BoneConnectionPoint.END);
 	}
 
 	@Override

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/ConnectedChainsWithEmbeddedTargets.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/ConnectedChainsWithEmbeddedTargets.java
@@ -1,10 +1,10 @@
 package au.edu.federation.caliko.demo3d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone3D;
 import au.edu.federation.caliko.FabrikChain3D;
-import au.edu.federation.caliko.FabrikStructure3D;
-import au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D;
 import au.edu.federation.caliko.FabrikChain3D.BaseboneConstraintType3D;
+import au.edu.federation.caliko.FabrikStructure3D;
 import au.edu.federation.caliko.visualisation.Point3D;
 import au.edu.federation.utils.Colour4f;
 import au.edu.federation.utils.Mat4f;
@@ -69,7 +69,7 @@ public class ConnectedChainsWithEmbeddedTargets extends CalikoDemoStructure3D {
 		secondChain.setColour(Utils.GREY);
 		
 		// Connect this second chain to the start point of bone 3 in chain 0 of the structure
-		this.structure.connectChain(secondChain, 0, 3, BoneConnectionPoint3D.START);
+		this.structure.connectChain(secondChain, 0, 3, BoneConnectionPoint.START);
 	}
 
 	@Override

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/ConnectedChainsWithFreelyRotatingGlobalHingesBaseboneConstraints.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/ConnectedChainsWithFreelyRotatingGlobalHingesBaseboneConstraints.java
@@ -1,9 +1,9 @@
 package au.edu.federation.caliko.demo3d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone3D;
 import au.edu.federation.caliko.FabrikChain3D;
 import au.edu.federation.caliko.FabrikStructure3D;
-import au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D;
 import au.edu.federation.utils.Colour4f;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
@@ -55,7 +55,7 @@ public class ConnectedChainsWithFreelyRotatingGlobalHingesBaseboneConstraints ex
 		secondChain.setColour(Utils.GREY);
 		
 		// Connect this second chain to the start point of bone 3 in chain 0 of the structure
-		this.structure.connectChain(secondChain, 0, 3, BoneConnectionPoint3D.START);
+		this.structure.connectChain(secondChain, 0, 3, BoneConnectionPoint.START);
 	}
 
 	@Override

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/GlobalRotorConstrainedConnectedChains.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/GlobalRotorConstrainedConnectedChains.java
@@ -1,10 +1,10 @@
 package au.edu.federation.caliko.demo3d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone3D;
 import au.edu.federation.caliko.FabrikChain3D;
-import au.edu.federation.caliko.FabrikStructure3D;
-import au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D;
 import au.edu.federation.caliko.FabrikChain3D.BaseboneConstraintType3D;
+import au.edu.federation.caliko.FabrikStructure3D;
 import au.edu.federation.utils.Colour4f;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
@@ -50,7 +50,7 @@ public class GlobalRotorConstrainedConnectedChains extends CalikoDemoStructure3D
 		secondChain.addConsecutiveBone(X_AXIS, 15.0f);
 		secondChain.setColour(Utils.RED);
 		
-		this.structure.connectChain(secondChain, 0, 3, BoneConnectionPoint3D.START);
+		this.structure.connectChain(secondChain, 0, 3, BoneConnectionPoint.START);
 		
 		FabrikChain3D thirdChain = new FabrikChain3D("Second Chain");
 		base = new FabrikBone3D( new Vec3f(), new Vec3f(0.0f, 15.0f, 0.0f) );
@@ -62,7 +62,7 @@ public class GlobalRotorConstrainedConnectedChains extends CalikoDemoStructure3D
 		thirdChain.addConsecutiveBone(Y_AXIS, 15.0f);
 		thirdChain.setColour(Utils.BLUE);
 		
-		this.structure.connectChain(thirdChain, 0, 6, BoneConnectionPoint3D.START);
+		this.structure.connectChain(thirdChain, 0, 6, BoneConnectionPoint.START);
 	}
 
 	@Override

--- a/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/LocalRotorConstrainedConnectedChains.java
+++ b/caliko-demo/src/main/java/au/edu/federation/caliko/demo3d/LocalRotorConstrainedConnectedChains.java
@@ -1,10 +1,10 @@
 package au.edu.federation.caliko.demo3d;
 
+import au.edu.federation.caliko.BoneConnectionPoint;
 import au.edu.federation.caliko.FabrikBone3D;
 import au.edu.federation.caliko.FabrikChain3D;
-import au.edu.federation.caliko.FabrikStructure3D;
-import au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D;
 import au.edu.federation.caliko.FabrikChain3D.BaseboneConstraintType3D;
+import au.edu.federation.caliko.FabrikStructure3D;
 import au.edu.federation.utils.Colour4f;
 import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
@@ -53,7 +53,7 @@ public class LocalRotorConstrainedConnectedChains extends CalikoDemoStructure3D 
 		secondChain.setColour(Utils.RED);
 		
 		// Connect this second chain to the start point of bone 3 in chain 0 of the structure
-		this.structure.connectChain(secondChain, 0, 3, BoneConnectionPoint3D.START);
+		this.structure.connectChain(secondChain, 0, 3, BoneConnectionPoint.START);
 	}
 
 	@Override

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Axis.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Axis.java
@@ -159,7 +159,7 @@ public class Axis
 					                                                     GL_FLOAT,  // Data type
 						                                                    true,   // Normalised?
 						                            COMPONENT_COUNT * Float.BYTES,  // Stride
-						                         VERTEX_COMPONENTS * Float.BYTES);  // Offset
+						                      (long)VERTEX_COMPONENTS * Float.BYTES);  // Offset
 				
 				// Unbind VBO
 				glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Axis.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Axis.java
@@ -28,7 +28,7 @@ public class Axis
 	// ----- Static Properties -----
 	
 	// Flag used so that we only initialise the shader once
-	private static boolean shaderInitialised = false;
+	private boolean shaderInitialised = false;
 
 	// We're drawing 3 lines and each line has 2 vertices, which brings our total to 6 vertices
 	private static final int NUM_VERTICES = 6;
@@ -43,10 +43,10 @@ public class Axis
 	private static final int COMPONENT_COUNT = VERTEX_COMPONENTS + COLOUR_COMPONENTS;
 	
 	// A single static ShaderProgram is used to draw all axes
-	private static ShaderProgram axisShaderProgram;
+	private ShaderProgram axisShaderProgram;
 
 	// Vertex shader source
-	private static String vertexShaderSource =
+	private static final String vertexShaderSource =
 			"#version 330"                                                                  + Utils.NEW_LINE +
 			"in vec3 vertexLocation;   // Incoming vertex attribute"                        + Utils.NEW_LINE +
 			"in vec4 vertexColour;     // Incoming colour value"                            + Utils.NEW_LINE +
@@ -58,7 +58,7 @@ public class Axis
 			"}";
 
 	// Fragment shader source
-	private static String fragmentShaderSource =
+	private static final String fragmentShaderSource =
 			"#version 330"                                                   + Utils.NEW_LINE +
 			"flat in vec4 fragColour; // Incoming colour from vertex shader" + Utils.NEW_LINE +
 			"out vec4 vOutputColour;  // Outgoing colour value"              + Utils.NEW_LINE +
@@ -67,18 +67,18 @@ public class Axis
 			"}";
 
     // Hold id values for the Vertex Array Object (VAO) and Vertex Buffer Object (VBO)
-	private static int axisVaoId;
-	private static int axisVboId;
+	private int axisVaoId;
+	private int axisVboId;
 	
 	/** The FloatBuffer which contains the ModelViewProjection matrix. */
-	private static FloatBuffer mvpMatrixFB;
+	private FloatBuffer mvpMatrixFB;
 	
 	// We'll keep track of and restore the current OpenGL line width, which we'll store in this FloatBuffer.
 	// Note: Although we only need a single float for this, LWJGL insists upon a minimum size of 16 floats.
-	private static FloatBuffer currentLineWidthFB;
+	private FloatBuffer currentLineWidthFB;
 	
 	// The FloatBuffer which will contain our vertex data
-	private static FloatBuffer vertexFloatBuffer;
+	private FloatBuffer vertexFloatBuffer;
 	
 	// ----- Non-Static Properties -----
 	
@@ -120,10 +120,6 @@ public class Axis
 
 			axisShaderProgram = new ShaderProgram();
 			axisShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
-
-			// We no longer need the shader sources
-			vertexShaderSource   = null;
-			fragmentShaderSource = null;
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Axis.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Axis.java
@@ -46,7 +46,7 @@ public class Axis
 	private ShaderProgram axisShaderProgram;
 
 	// Vertex shader source
-	private static final String vertexShaderSource =
+	private static final String VERTEX_SHADER_SOURCE =
 			"#version 330"                                                                  + Utils.NEW_LINE +
 			"in vec3 vertexLocation;   // Incoming vertex attribute"                        + Utils.NEW_LINE +
 			"in vec4 vertexColour;     // Incoming colour value"                            + Utils.NEW_LINE +
@@ -58,7 +58,7 @@ public class Axis
 			"}";
 
 	// Fragment shader source
-	private static final String fragmentShaderSource =
+	private static final String FRAGMENT_SHADER_SOURCE =
 			"#version 330"                                                   + Utils.NEW_LINE +
 			"flat in vec4 fragColour; // Incoming colour from vertex shader" + Utils.NEW_LINE +
 			"out vec4 vOutputColour;  // Outgoing colour value"              + Utils.NEW_LINE +
@@ -119,7 +119,7 @@ public class Axis
 			// ----- Grid shader program setup -----
 
 			axisShaderProgram = new ShaderProgram();
-			axisShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
+			axisShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Circle3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Circle3D.java
@@ -42,7 +42,7 @@ public class Circle3D
 	private FloatBuffer currentLineWidthFB;
 	
 	//Define our vertex and fragement shader GLSL source code
-	private static final String vertexShaderSource =
+	private static final String VERTEX_SHADER_SOURCE =
 			"#version 330"                                                         + Utils.NEW_LINE +
 			"in vec4 vertexLocation; // Incoming vertex attribute"                 + Utils.NEW_LINE +
 			"out vec4 fragColour;    // Outgoing colour value"                     + Utils.NEW_LINE +
@@ -51,7 +51,7 @@ public class Circle3D
 			"	gl_Position = mvpMatrix * vertexLocation; // Project our geometry" + Utils.NEW_LINE +
 			"}";
 
-	private static final String fragmentShaderSource =
+	private static final String FRAGMENT_SHADER_SOURCE =
 			"#version 330"                                     + Utils.NEW_LINE +
 			"out vec4 vOutputColour; // Outgoing colour value" + Utils.NEW_LINE +
 			"uniform vec4 fragColour;"                         + Utils.NEW_LINE +
@@ -89,7 +89,7 @@ public class Circle3D
 			// ----- Shader program setup -----
 
 			circleShaderProgram = new ShaderProgram();
-			circleShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
+			circleShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
 
 			// Add the shader attributes and uniforms
 			circleShaderProgram.addAttribute("vertexLocation");

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Circle3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Circle3D.java
@@ -26,20 +26,17 @@ public class Circle3D
 	private static final int NUM_VERTICES      = 40;
 	private static final int VERTEX_COMPONENTS = 3;
 	
-	// Flag used so that we only initialise the shader once
-	private boolean shaderInitialised = false;
-
 	/** Shader program to draw all circles. **/
-	private ShaderProgram circleShaderProgram;
+	private static ShaderProgram circleShaderProgram;
 	
 	/** Static FloatBuffer to hold the ModelViewProjection matrix - this gets updated in the draw() method. */
-	private FloatBuffer mvpMatrixFB;
+	private static FloatBuffer mvpMatrixFB;
 	
 	/** Static FloatBuffer to hold the colour to draw the circle. */
-	private FloatBuffer colourFB;
+	private static FloatBuffer colourFB;
 	
 	/** Static FloatBuffer to store and restore the current line width used to draw the circle. */
-	private FloatBuffer currentLineWidthFB;
+	private static FloatBuffer currentLineWidthFB;
 	
 	//Define our vertex and fragement shader GLSL source code
 	private static final String VERTEX_SHADER_SOURCE =
@@ -60,72 +57,70 @@ public class Circle3D
 			"}";
 
 	/** Static Vertex Array Object )VAO) id. */
-	private int circleVaoId;
+	private static int circleVaoId;
 	
 	/** Static Vertex Buffer Object (VBO) id. */
-	private int circleVboId;       
+	private static int circleVboId;       
 	
     /** Static array of floats used to draw the circle. */
-	private float[] circleData;
+	private static float[] circleData;
 	
     /** Static vertex FloatBuffer to hold our vertex data. */
-	private FloatBuffer vertexFB;
+	private static FloatBuffer vertexFB;
+	
+	static {
+		// Allocate memory for arrays and buffers
+		circleData         = new float[NUM_VERTICES * VERTEX_COMPONENTS];
+		vertexFB           = Utils.createFloatBuffer(NUM_VERTICES * VERTEX_COMPONENTS);
+		mvpMatrixFB        = Utils.createFloatBuffer(16);
+		colourFB           = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 1 float
+		currentLineWidthFB = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 1 float
+
+		// ----- Shader program setup -----
+
+		circleShaderProgram = new ShaderProgram();
+		circleShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
+
+		// Add the shader attributes and uniforms
+		circleShaderProgram.addAttribute("vertexLocation");
+		circleShaderProgram.addUniform("mvpMatrix");
+		circleShaderProgram.addUniform("fragColour");
+
+		// Get an id for the Vertex Array Object (VAO) and bind to it
+		circleVaoId = glGenVertexArrays();
+		glBindVertexArray(circleVaoId);
+
+		// Generate an id for our Vertex Buffer Object (VBO) and bind to it
+		circleVboId = glGenBuffers();
+		glBindBuffer(GL_ARRAY_BUFFER, circleVboId);
+
+		// Place the location data into the VBO...
+		glBufferData(GL_ARRAY_BUFFER, vertexFB, GL_DYNAMIC_DRAW);
+
+		// ...and specify the data format.
+		glVertexAttribPointer(circleShaderProgram.attribute("vertexLocation"),  // Vertex location attribute index
+				                                            VERTEX_COMPONENTS,  // Number of normal components per vertex
+				                                                     GL_FLOAT,  // Data type
+				                                                        false,  // Normalised?
+				                                                            0,  // Stride
+				                                                            0); // Offset
+		
+		// Unbind VBO
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+		// Enable the vertex attributes
+		glEnableVertexAttribArray(circleShaderProgram.attribute("vertexLocation"));
+
+		// Unbind our from our VAO, saving all settings
+		glBindVertexArray(0);
+	}
 
 	/** Constructor */
 	public Circle3D()
 	{
-		// If this is the first grid we're creating then do the shader setup
-		if (!shaderInitialised)
-		{
-			shaderInitialised = true;
-			
-			// Allocate memory for arrays and buffers
-			circleData         = new float[NUM_VERTICES * VERTEX_COMPONENTS];
-			vertexFB           = Utils.createFloatBuffer(NUM_VERTICES * VERTEX_COMPONENTS);
-			mvpMatrixFB        = Utils.createFloatBuffer(16);
-			colourFB           = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 1 float
-			currentLineWidthFB = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 1 float
-
-			// ----- Shader program setup -----
-
-			circleShaderProgram = new ShaderProgram();
-			circleShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
-
-			// Add the shader attributes and uniforms
-			circleShaderProgram.addAttribute("vertexLocation");
-			circleShaderProgram.addUniform("mvpMatrix");
-			circleShaderProgram.addUniform("fragColour");
-
-			// Get an id for the Vertex Array Object (VAO) and bind to it
-			circleVaoId = glGenVertexArrays();
-			glBindVertexArray(circleVaoId);
-
-			// Generate an id for our Vertex Buffer Object (VBO) and bind to it
-			circleVboId = glGenBuffers();
-			glBindBuffer(GL_ARRAY_BUFFER, circleVboId);
-
-			// Place the location data into the VBO...
-			glBufferData(GL_ARRAY_BUFFER, vertexFB, GL_DYNAMIC_DRAW);
-
-			// ...and specify the data format.
-			glVertexAttribPointer(circleShaderProgram.attribute("vertexLocation"),  // Vertex location attribute index
-					                                            VERTEX_COMPONENTS,  // Number of normal components per vertex
-					                                                     GL_FLOAT,  // Data type
-					                                                        false,  // Normalised?
-					                                                            0,  // Stride
-					                                                            0); // Offset
-			
-			// Unbind VBO
-			glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-			// Enable the vertex attributes
-			glEnableVertexAttribArray(circleShaderProgram.attribute("vertexLocation"));
-
-			// Unbind our from our VAO, saving all settings
-			glBindVertexArray(0);
-		}
+		//
 	}
-
+	
 	/**
 	 * Draw a circle in 3D space.
 	 * <p>
@@ -152,10 +147,7 @@ public class Circle3D
 			// Translate to the given location
 			point = point.plus(location);
 			
-			// Point x/y/z
-			circleData[(vertexNumLoop * VERTEX_COMPONENTS)    ] = point.x;
-			circleData[(vertexNumLoop * VERTEX_COMPONENTS) + 1] = point.y;
-			circleData[(vertexNumLoop * VERTEX_COMPONENTS) + 2] = point.z;
+			setCircleData(vertexNumLoop, point);
 		}
 		
 		// Transfer the data into the vertex float buffer
@@ -174,34 +166,42 @@ public class Circle3D
 		circleShaderProgram.use();
 		glBindVertexArray(circleVaoId);
 
-			// Bind to the vertex buffer object (VBO) and place the new data into it
-			glBindBuffer(GL_ARRAY_BUFFER, circleVboId);
-			glBufferData(GL_ARRAY_BUFFER, vertexFB, GL_DYNAMIC_DRAW);
-	
-			// Provide the projection matrix and colour uniforms to our shader
-			glUniformMatrix4fv(circleShaderProgram.uniform("mvpMatrix"), false, mvpMatrixFB);
-			glUniform4fv(circleShaderProgram.uniform("fragColour"), colourFB);
-	
-			// Store the current GL_LINE_WIDTH
-			// IMPORTANT: We MUST allocate a minimum of 16 floats in our FloatBuffer in LWJGL, we CANNOT just get a FloatBuffer with 1 float!
-			// ALSO: glPushAttrib(GL_LINE_BIT); /* do stuff */ glPopAttrib(); should work instead of this in theory - but LWJGL fails with 'function not supported'.
-			glGetFloatv(GL_LINE_WIDTH, currentLineWidthFB);
-	
-			/// Set the GL_LINE_WIDTH to be the width requested, as passed to the constructor
-			glLineWidth(lineWidth);
-	
-			// 	Draw the circle as a line loop
-			glDrawArrays(GL_LINE_LOOP, 0, NUM_VERTICES);
-	
-			// Restore the previous GL_LINE_WIDTH
-			glLineWidth( currentLineWidthFB.get(0) );
+		// Bind to the vertex buffer object (VBO) and place the new data into it
+		glBindBuffer(GL_ARRAY_BUFFER, circleVboId);
+		glBufferData(GL_ARRAY_BUFFER, vertexFB, GL_DYNAMIC_DRAW);
 
-			// Unbind from VBO & VAO, then disable our shader
-			glBindBuffer(GL_ARRAY_BUFFER, 0);
+		// Provide the projection matrix and colour uniforms to our shader
+		glUniformMatrix4fv(circleShaderProgram.uniform("mvpMatrix"), false, mvpMatrixFB);
+		glUniform4fv(circleShaderProgram.uniform("fragColour"), colourFB);
+
+		// Store the current GL_LINE_WIDTH
+		// IMPORTANT: We MUST allocate a minimum of 16 floats in our FloatBuffer in LWJGL, we CANNOT just get a FloatBuffer with 1 float!
+		// ALSO: glPushAttrib(GL_LINE_BIT); /* do stuff */ glPopAttrib(); should work instead of this in theory - but LWJGL fails with 'function not supported'.
+		glGetFloatv(GL_LINE_WIDTH, currentLineWidthFB);
+
+		/// Set the GL_LINE_WIDTH to be the width requested, as passed to the constructor
+		glLineWidth(lineWidth);
+
+		// 	Draw the circle as a line loop
+		glDrawArrays(GL_LINE_LOOP, 0, NUM_VERTICES);
+
+		// Restore the previous GL_LINE_WIDTH
+		glLineWidth( currentLineWidthFB.get(0) );
+
+		// Unbind from VBO & VAO, then disable our shader
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
 			
 		glBindVertexArray(0);
 		circleShaderProgram.disable();
 	
 	} // End of draw method
+	
+	private static void setCircleData(int vertexNumLoop, Vec3f point) {
+		// Point x/y/z
+		circleData[(vertexNumLoop * VERTEX_COMPONENTS)    ] = point.x;
+		circleData[(vertexNumLoop * VERTEX_COMPONENTS) + 1] = point.y;
+		circleData[(vertexNumLoop * VERTEX_COMPONENTS) + 2] = point.z;		
+	}
+	
 	
 } // End of Circle3D class

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Circle3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Circle3D.java
@@ -27,22 +27,22 @@ public class Circle3D
 	private static final int VERTEX_COMPONENTS = 3;
 	
 	// Flag used so that we only initialise the shader once
-	private static boolean shaderInitialised = false;
+	private boolean shaderInitialised = false;
 
 	/** Shader program to draw all circles. **/
-	private static ShaderProgram circleShaderProgram;
+	private ShaderProgram circleShaderProgram;
 	
 	/** Static FloatBuffer to hold the ModelViewProjection matrix - this gets updated in the draw() method. */
-	private static FloatBuffer mvpMatrixFB;
+	private FloatBuffer mvpMatrixFB;
 	
 	/** Static FloatBuffer to hold the colour to draw the circle. */
-	private static FloatBuffer colourFB;
+	private FloatBuffer colourFB;
 	
 	/** Static FloatBuffer to store and restore the current line width used to draw the circle. */
-	private static FloatBuffer currentLineWidthFB;
+	private FloatBuffer currentLineWidthFB;
 	
 	//Define our vertex and fragement shader GLSL source code
-	private static String vertexShaderSource =
+	private static final String vertexShaderSource =
 			"#version 330"                                                         + Utils.NEW_LINE +
 			"in vec4 vertexLocation; // Incoming vertex attribute"                 + Utils.NEW_LINE +
 			"out vec4 fragColour;    // Outgoing colour value"                     + Utils.NEW_LINE +
@@ -51,7 +51,7 @@ public class Circle3D
 			"	gl_Position = mvpMatrix * vertexLocation; // Project our geometry" + Utils.NEW_LINE +
 			"}";
 
-	private static String fragmentShaderSource =
+	private static final String fragmentShaderSource =
 			"#version 330"                                     + Utils.NEW_LINE +
 			"out vec4 vOutputColour; // Outgoing colour value" + Utils.NEW_LINE +
 			"uniform vec4 fragColour;"                         + Utils.NEW_LINE +
@@ -60,16 +60,16 @@ public class Circle3D
 			"}";
 
 	/** Static Vertex Array Object )VAO) id. */
-	private static int circleVaoId;
+	private int circleVaoId;
 	
 	/** Static Vertex Buffer Object (VBO) id. */
-	private static int circleVboId;       
+	private int circleVboId;       
 	
     /** Static array of floats used to draw the circle. */
-	private static float[] circleData;
+	private float[] circleData;
 	
     /** Static vertex FloatBuffer to hold our vertex data. */
-	private static FloatBuffer vertexFB;
+	private FloatBuffer vertexFB;
 
 	/** Constructor */
 	public Circle3D()
@@ -90,10 +90,6 @@ public class Circle3D
 
 			circleShaderProgram = new ShaderProgram();
 			circleShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
-
-			// We no longer need the shader sources now we have a compiled shader
-			vertexShaderSource   = null;
-			fragmentShaderSource = null;
 
 			// Add the shader attributes and uniforms
 			circleShaderProgram.addAttribute("vertexLocation");

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Entity.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Entity.java
@@ -22,19 +22,19 @@ public class Entity
 	// ---------- Static Properties ----------
 	
 	/** Projection matrix float buffer - static because all entities will have a 4x4 projection matrix we can overwrite rather than allocate new memory to. */
-	private static FloatBuffer projectionMatrixFB;
+	private FloatBuffer projectionMatrixFB;
 	
 	/** View matrix float buffer - static because all entities will have a 4x4 view matrix we can overwrite rather than allocate new memory to. */
-	private static FloatBuffer viewMatrixFB;
+	private FloatBuffer viewMatrixFB;
 	
 	/** Model matrix float buffer - static because all entities will have a 4x4 model matrix we can overwrite rather than allocate new memory to. */
-	private static FloatBuffer modelMatrixFB;
+	private FloatBuffer modelMatrixFB;
 	
 	/** Normal matrix float buffer - static because all entities will have a 4x4 normal matrix we can overwrite rather than allocate new memory to. */
-	private static FloatBuffer normalMatrixFB;
+	private FloatBuffer normalMatrixFB;
 	
 	/** How many entities exist - if this is zero (which it will be on startup as that's the default) then buffers are allocated in the constructor. */
-	private static int numEntities = 0;
+	private int numEntities = 0;
 
 	// ---------- Private Properties ------------
 	

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikConstraint3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikConstraint3D.java
@@ -21,12 +21,12 @@ public class FabrikConstraint3D
 	private static final float DEGS_TO_RADS = (float)Math.PI / 180.0f;
 	
 	// Constraint colours
-	private static Colour4f ANTICLOCKWISE_CONSTRAINT_COLOUR = new Colour4f(1.0f, 0.0f, 0.0f, 1.0f);
-	private static Colour4f CLOCKWISE_CONSTRAINT_COLOUR     = new Colour4f(0.0f, 0.0f, 1.0f, 1.0f);	
-	private static Colour4f BALL_JOINT_COLOUR               = new Colour4f(1.0f, 0.0f, 0.0f, 1.0f);
-	private static Colour4f GLOBAL_HINGE_COLOUR             = new Colour4f(1.0f, 1.0f, 0.0f, 1.0f);
-	private static Colour4f LOCAL_HINGE_COLOUR              = new Colour4f(0.0f, 1.0f, 1.0f, 1.0f);
-	private static Colour4f REFERENCE_AXIS_COLOUR           = new Colour4f(1.0f, 0.0f, 1.0f, 1.0f);
+	private static final Colour4f ANTICLOCKWISE_CONSTRAINT_COLOUR = new Colour4f(1.0f, 0.0f, 0.0f, 1.0f);
+	private static final Colour4f CLOCKWISE_CONSTRAINT_COLOUR     = new Colour4f(0.0f, 0.0f, 1.0f, 1.0f);	
+	private static final Colour4f BALL_JOINT_COLOUR               = new Colour4f(1.0f, 0.0f, 0.0f, 1.0f);
+	private static final Colour4f GLOBAL_HINGE_COLOUR             = new Colour4f(1.0f, 1.0f, 0.0f, 1.0f);
+	private static final Colour4f LOCAL_HINGE_COLOUR              = new Colour4f(0.0f, 1.0f, 1.0f, 1.0f);
+	private static final Colour4f REFERENCE_AXIS_COLOUR           = new Colour4f(1.0f, 0.0f, 1.0f, 1.0f);
 	
 	// The drawn length of the rotor cone and the radius of the cone and circle describing the hinge axes
 	private static final float CONE_LENGTH_FACTOR  = 0.3f;

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikConstraint3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikConstraint3D.java
@@ -148,9 +148,9 @@ public class FabrikConstraint3D
 				     !Utils.approximatelyEquals(    clockwiseConstraintDegs, 180.0f, 0.01f) )
 				{	
 					// Get the relative hinge rotation axis and draw it...
-					Vec3f relativeHingeReferenceAxis = bone.getJoint().getHingeReferenceAxis().projectOntoPlane(relativeHingeRotationAxis);
+					bone.getJoint().getHingeReferenceAxis().projectOntoPlane(relativeHingeRotationAxis);
 					
-					relativeHingeReferenceAxis = m.times(bone.getJoint().getHingeReferenceAxis()).normalise();
+					Vec3f relativeHingeReferenceAxis = m.times(bone.getJoint().getHingeReferenceAxis()).normalise();
 					
 					mLine.draw(lineStart, lineStart.plus( relativeHingeReferenceAxis.times(radius) ), REFERENCE_AXIS_COLOUR, lineWidth, mvpMatrix);
 					

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikLine3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikLine3D.java
@@ -21,6 +21,8 @@ public class FabrikLine3D
 	// A static Line3D object used to draw lines.
 	private static Line3D line = new Line3D();
 	
+	private FabrikLine3D() {}
+	
 	// ---------- Bone Drawing Methods ----------
 	
 	/**

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikModel3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikModel3D.java
@@ -24,16 +24,16 @@ import static org.lwjgl.opengl.GL30.*;
 public class FabrikModel3D
 {	
 	// Flag used so that we only initialise the shader once
-	private static boolean shaderInitialised = false;
+	private boolean shaderInitialised = false;
 
 	// Each vertex has three positional components - the x, y and z values. 
 	private static final int VERTEX_COMPONENTS = 3;
 	
 	// A single static ShaderProgram is used to draw all axes
-	private static ShaderProgram shaderProgram;
+	private ShaderProgram shaderProgram;
 	
 	// Vertex shader source
-	private static String vertexShaderSource =
+	private static final String vertexShaderSource =
 			"#version 330"                                                                    + Utils.NEW_LINE +
 			"in vec3 vertexLocation;   // Incoming vertex attribute"                          + Utils.NEW_LINE +
 			"uniform mat4 mvpMatrix;   // Combined Model/View/Projection matrix  "            + Utils.NEW_LINE +
@@ -42,7 +42,7 @@ public class FabrikModel3D
 			"}";
 
 	// Fragment shader source
-	private static String fragmentShaderSource =
+	private static final String fragmentShaderSource =
 			"#version 330"              + Utils.NEW_LINE +
 			"out vec4 outputColour;"    + Utils.NEW_LINE +
 			"uniform vec4 colour;"      + Utils.NEW_LINE +
@@ -55,12 +55,12 @@ public class FabrikModel3D
 	private int vboId;
 	
 	// Float buffers for the ModelViewProjection matrix and model colour
-	private static FloatBuffer mvpMatrixFB;
-	private static FloatBuffer colourFB;
+	private FloatBuffer mvpMatrixFB;
+	private FloatBuffer colourFB;
 	
 	// We'll keep track of and restore the current OpenGL line width, which we'll store in this FloatBuffer.
 	// Note: Although we only need a single float for this, LWJGL insists upon a minimum size of 16 floats.
-	private static FloatBuffer currentLineWidthFB;	
+	private FloatBuffer currentLineWidthFB;	
 	
 	// ----- Non-Static Properties -----
 	
@@ -110,10 +110,6 @@ public class FabrikModel3D
 
 			shaderProgram = new ShaderProgram();
 			shaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
-
-			// We no longer need the shader sources
-			vertexShaderSource   = null;
-			fragmentShaderSource = null;
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikModel3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/FabrikModel3D.java
@@ -33,7 +33,7 @@ public class FabrikModel3D
 	private ShaderProgram shaderProgram;
 	
 	// Vertex shader source
-	private static final String vertexShaderSource =
+	private static final String VERTEX_SHADER_SOURCE =
 			"#version 330"                                                                    + Utils.NEW_LINE +
 			"in vec3 vertexLocation;   // Incoming vertex attribute"                          + Utils.NEW_LINE +
 			"uniform mat4 mvpMatrix;   // Combined Model/View/Projection matrix  "            + Utils.NEW_LINE +
@@ -42,7 +42,7 @@ public class FabrikModel3D
 			"}";
 
 	// Fragment shader source
-	private static final String fragmentShaderSource =
+	private static final String FRAGMENT_SHADER_SOURCE =
 			"#version 330"              + Utils.NEW_LINE +
 			"out vec4 outputColour;"    + Utils.NEW_LINE +
 			"uniform vec4 colour;"      + Utils.NEW_LINE +
@@ -109,7 +109,7 @@ public class FabrikModel3D
 			// ----- Grid shader program setup -----
 
 			shaderProgram = new ShaderProgram();
-			shaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
+			shaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Grid.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Grid.java
@@ -17,17 +17,14 @@ public class Grid
     /** Each vertex has an X, Y and Z component. */
 	private static final int VERTEX_COMPONENTS = 3;
 	
-	/** Flag used so that we only initialise the shader once. */
-	private boolean shaderInitialised = false;
-
 	/** The shader program used to draw all grids. */
-	private ShaderProgram gridShaderProgram;
+	private static ShaderProgram gridShaderProgram;
 
 	/** The ModelViewProjection matrix float buffer used to draw any given grid which is updated via the draw() method. */
-	private FloatBuffer mvpMatrixFB;
+	private static FloatBuffer mvpMatrixFB;
 	
 	/** The FloatBuffer used to get and restore the current line width. */
-	private FloatBuffer currentLineWidthFB = Utils.createFloatBuffer(16);
+	private static FloatBuffer currentLineWidthFB = Utils.createFloatBuffer(16);
 
 	//Define our vertex shader source code
 	//Note: The R" notation is for raw strings and preserves all spaces, indentation,
@@ -56,6 +53,17 @@ public class Grid
 	private int         numVerts;           // How many vertices in this grid?
 	private float[]     gridArray;          // Array of floats used to draw the grid
 	private FloatBuffer vertexFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
+	
+	static {
+		// Create our MVP matrix float buffer
+		mvpMatrixFB = Utils.createFloatBuffer(16);
+
+		// Set up out shader
+		gridShaderProgram = new ShaderProgram();
+		gridShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
+		gridShaderProgram.addAttribute("vertexLocation");
+		gridShaderProgram.addUniform("mvpMatrix");
+	}
 
 	/**
 	 * Constructor.
@@ -82,22 +90,6 @@ public class Grid
 		// ...which we'll store in this float array!
 		gridArray = new float[gridFloatCount];
 
-		// If this is the first grid we're creating then do the shader setup
-		if (!shaderInitialised)
-		{
-			// Set the flag so we never initialise the shader again
-			shaderInitialised = true;
-
-			// Create our MVP matrix float buffer
-			mvpMatrixFB = Utils.createFloatBuffer(16);
-
-			// Set up out shader
-			gridShaderProgram = new ShaderProgram();
-			gridShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
-			gridShaderProgram.addAttribute("vertexLocation");
-			gridShaderProgram.addUniform("mvpMatrix");
-		}
-		
 		// For a grid of width and depth, the extent goes from -halfWidth to +halfWidth,
 		// and -halfDepth to +halfDepth.
 		float halfWidth = width / 2.0f;

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Grid.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Grid.java
@@ -32,7 +32,7 @@ public class Grid
 	//Define our vertex shader source code
 	//Note: The R" notation is for raw strings and preserves all spaces, indentation,
 	//newlines etc. in utf-8|16|32 wchar_t format, but requires C++0x or C++11.
-	private static final String vertexShaderSource =
+	private static final String VERTEX_SHADER_SOURCE =
 			"#version 330"                                                                    + Utils.NEW_LINE +
 			"in vec3 vertexLocation; // Incoming vertex attribute"                            + Utils.NEW_LINE +
 			"uniform mat4 mvpMatrix; // Combined Model/View/Projection matrix"                + Utils.NEW_LINE +
@@ -41,7 +41,7 @@ public class Grid
 			"}";
 
 	//Define our fragment shader source code
-	private static String fragmentShaderSource =
+	private static final String FRAGMENT_SHADER_SOURCE =
 			"#version 330"                                                               + Utils.NEW_LINE +
 			"out vec4 vOutputColour; // Outgoing colour value"                           + Utils.NEW_LINE +
 			"void main() {"                                                              + Utils.NEW_LINE +
@@ -93,7 +93,7 @@ public class Grid
 
 			// Set up out shader
 			gridShaderProgram = new ShaderProgram();
-			gridShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
+			gridShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
 			gridShaderProgram.addAttribute("vertexLocation");
 			gridShaderProgram.addUniform("mvpMatrix");
 		}

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Grid.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Grid.java
@@ -18,21 +18,21 @@ public class Grid
 	private static final int VERTEX_COMPONENTS = 3;
 	
 	/** Flag used so that we only initialise the shader once. */
-	private static boolean shaderInitialised = false;
+	private boolean shaderInitialised = false;
 
 	/** The shader program used to draw all grids. */
-	private static ShaderProgram gridShaderProgram;
+	private ShaderProgram gridShaderProgram;
 
 	/** The ModelViewProjection matrix float buffer used to draw any given grid which is updated via the draw() method. */
-	private static FloatBuffer mvpMatrixFB;
+	private FloatBuffer mvpMatrixFB;
 	
 	/** The FloatBuffer used to get and restore the current line width. */
-	private static FloatBuffer currentLineWidthFB = Utils.createFloatBuffer(16);
+	private FloatBuffer currentLineWidthFB = Utils.createFloatBuffer(16);
 
 	//Define our vertex shader source code
 	//Note: The R" notation is for raw strings and preserves all spaces, indentation,
 	//newlines etc. in utf-8|16|32 wchar_t format, but requires C++0x or C++11.
-	private static String vertexShaderSource =
+	private static final String vertexShaderSource =
 			"#version 330"                                                                    + Utils.NEW_LINE +
 			"in vec3 vertexLocation; // Incoming vertex attribute"                            + Utils.NEW_LINE +
 			"uniform mat4 mvpMatrix; // Combined Model/View/Projection matrix"                + Utils.NEW_LINE +

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line2D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line2D.java
@@ -30,14 +30,11 @@ public class Line2D
 	// Total number of float components per vertex (2 + 4 = 6)
 	private static final int COMPONENT_COUNT = VERTEX_COMPONENTS + COLOUR_COMPONENTS;
 
-	// Flag used so that we only initialise the shader once
-	private boolean shaderInitialised = false;
-
 	/** Static ShaderProgram shared across all Line2D instances. */
-	private ShaderProgram lineShaderProgram;
+	private static ShaderProgram lineShaderProgram;
 
 	/** Static FloatBuffer to hold the ModelViewProjection matrix - shared across all line 2D instances and updated for each line drawn. */
-	private FloatBuffer mvpMatrixFloatBuffer;
+	private static FloatBuffer mvpMatrixFloatBuffer;
 
 	/** GLSL version 330 fragment shader code. */	
 	private static final String VERTEX_SHADER_SOURCE =
@@ -60,82 +57,80 @@ public class Line2D
 			"	vOutputColour = fragColour;"                                + Utils.NEW_LINE +
 			"}";
 
-	private int         lineVaoId;             // The Vertex Array Object ID which holds our shader attributes
-	private int         lineVertexBufferId;    // The id of the vertex buffer containing the grid vertex data
-	private float[]     lineData;              // Array of floats used to draw the grid
-	private FloatBuffer vertexFloatBuffer;     // Vertex buffer to hold the gridArray vertex data
-	private FloatBuffer lineWidthFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
+	private static int         lineVaoId;             // The Vertex Array Object ID which holds our shader attributes
+	private static int         lineVertexBufferId;    // The id of the vertex buffer containing the grid vertex data
+	private static float[]     lineData;              // Array of floats used to draw the grid
+	private static FloatBuffer vertexFloatBuffer;     // Vertex buffer to hold the gridArray vertex data
+	private static FloatBuffer lineWidthFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
+	
+	static {
+		lineData = new float[NUM_VERTICES * COMPONENT_COUNT];
+		vertexFloatBuffer = Utils.createFloatBuffer(NUM_VERTICES * COMPONENT_COUNT);
+		mvpMatrixFloatBuffer = Utils.createFloatBuffer(16);
+		lineWidthFloatBuffer = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 1 float			
+
+		// ----- Grid shader program setup -----
+
+		lineShaderProgram = new ShaderProgram();
+
+		lineShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
+
+		// ----- Grid shader attributes and uniforms -----
+
+		// Add the shader attributes
+		lineShaderProgram.addAttribute("vertexLocation");
+		lineShaderProgram.addAttribute("vertexColour");
+
+		// Add the shader uniforms
+		lineShaderProgram.addUniform("mvpMatrix");
+
+
+		// ----- Set up our Vertex Array Object (VAO) to hold the shader attributes -----
+
+		// Get an Id for the Vertex Array Object (VAO) and bind to it
+		lineVaoId = glGenVertexArrays();
+		glBindVertexArray(lineVaoId);
+
+		// ----- Location Vertex Buffer Object (VBO) -----
+
+		// Generate an id for the locationBuffer and bind to it
+		lineVertexBufferId = glGenBuffers();
+		glBindBuffer(GL_ARRAY_BUFFER, lineVertexBufferId);
+
+		// Place the location data into the VBO...
+		glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
+
+		// ...and specify the data format.
+		glVertexAttribPointer(lineShaderProgram.attribute("vertexLocation"), // Vertex location attribute index
+                                                            VERTEX_COMPONENTS, // Number of normal components per vertex
+                                                                     GL_FLOAT, // Data type
+                                                                        false, // Normalised?
+                                                COMPONENT_COUNT * Float.BYTES, // Stride
+                                                                           0); // Offset
+
+		// ...and specify the data format.
+		glVertexAttribPointer(lineShaderProgram.attribute("vertexColour"),  // Vertex colour attribute index
+                                                          COLOUR_COMPONENTS,  // Number of colour components per vertex
+                                                                   GL_FLOAT,  // Data type
+                                                                       true,  // Normalised? Colour values are between 0.0 and 1.0, so yes!
+                                              COMPONENT_COUNT * Float.BYTES,  // Stride
+                                      (long)VERTEX_COMPONENTS * Float.BYTES);  // Offset
+		
+		// Unbind VBO
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+		// Enable the vertex attributes
+		glEnableVertexAttribArray(lineShaderProgram.attribute("vertexLocation"));
+		glEnableVertexAttribArray(lineShaderProgram.attribute("vertexColour"));
+
+		// Unbind our Vertex Array object - all the buffer and attribute settings above will be associated with our VAO!
+		glBindVertexArray(0);
+	}
 
 	/** Constructor */
 	public Line2D()
 	{
-		// If this is the first grid we're creating then do the shader setup
-		if (!shaderInitialised)
-		{
-			shaderInitialised = true;
-			
-			lineData = new float[NUM_VERTICES * COMPONENT_COUNT];
-			vertexFloatBuffer = Utils.createFloatBuffer(NUM_VERTICES * COMPONENT_COUNT);
-			mvpMatrixFloatBuffer = Utils.createFloatBuffer(16);
-			lineWidthFloatBuffer = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 1 float			
-
-			// ----- Grid shader program setup -----
-
-			lineShaderProgram = new ShaderProgram();
-
-			lineShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
-
-			// ----- Grid shader attributes and uniforms -----
-
-			// Add the shader attributes
-			lineShaderProgram.addAttribute("vertexLocation");
-			lineShaderProgram.addAttribute("vertexColour");
-
-			// Add the shader uniforms
-			lineShaderProgram.addUniform("mvpMatrix");
-
-
-			// ----- Set up our Vertex Array Object (VAO) to hold the shader attributes -----
-
-			// Get an Id for the Vertex Array Object (VAO) and bind to it
-			lineVaoId = glGenVertexArrays();
-			glBindVertexArray(lineVaoId);
-
-			// ----- Location Vertex Buffer Object (VBO) -----
-
-			// Generate an id for the locationBuffer and bind to it
-			lineVertexBufferId = glGenBuffers();
-			glBindBuffer(GL_ARRAY_BUFFER, lineVertexBufferId);
-
-			// Place the location data into the VBO...
-			glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
-
-			// ...and specify the data format.
-			glVertexAttribPointer(lineShaderProgram.attribute("vertexLocation"), // Vertex location attribute index
-                                                              VERTEX_COMPONENTS, // Number of normal components per vertex
-                                                                       GL_FLOAT, // Data type
-                                                                          false, // Normalised?
-                                                  COMPONENT_COUNT * Float.BYTES, // Stride
-                                                                             0); // Offset
-
-			// ...and specify the data format.
-			glVertexAttribPointer(lineShaderProgram.attribute("vertexColour"),  // Vertex colour attribute index
-                                                            COLOUR_COMPONENTS,  // Number of colour components per vertex
-                                                                     GL_FLOAT,  // Data type
-                                                                         true,  // Normalised? Colour values are between 0.0 and 1.0, so yes!
-                                                COMPONENT_COUNT * Float.BYTES,  // Stride
-                                        (long)VERTEX_COMPONENTS * Float.BYTES);  // Offset
-			
-			// Unbind VBO
-			glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-			// Enable the vertex attributes
-			glEnableVertexAttribArray(lineShaderProgram.attribute("vertexLocation"));
-			glEnableVertexAttribArray(lineShaderProgram.attribute("vertexColour"));
-
-			// Unbind our Vertex Array object - all the buffer and attribute settings above will be associated with our VAO!
-			glBindVertexArray(0);
-		}
+		//
 	}
 
 	/**
@@ -150,25 +145,7 @@ public class Line2D
 	 */
 	public void draw(Vec2f p1, Vec2f p2, Colour4f c1, Colour4f c2, float lineWidth, Mat4f mvpMatrix)
 	{
-		// First vertex x/y location
-		lineData[0] = p1.x;
-		lineData[1] = p1.y;
-
-		// First vertex colour
-		lineData[2]  = c1.r;
-		lineData[3]  = c1.g;
-		lineData[4]  = c1.b;
-		lineData[5]  = c1.a;
-
-		// Second vertex x/y location
-		lineData[6]  = p2.x;
-		lineData[7]  = p2.y;
-
-		// Second vertex colour
-		lineData[8]  = c2.r;
-		lineData[9]  = c2.g;
-		lineData[10] = c2.b;
-		lineData[11] = c2.a;
+		setLineData(p1, p2, c1, c2);
 
 		// Transfer the data into the vertex float buffer
 		vertexFloatBuffer.put(lineData);
@@ -188,22 +165,22 @@ public class Line2D
 		glBindBuffer(GL_ARRAY_BUFFER, lineVertexBufferId);
 		glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
 
-			// Provide the projection matrix uniform
-			glUniformMatrix4fv(lineShaderProgram.uniform("mvpMatrix"), false, mvpMatrixFloatBuffer);
-	
-			// Store the current GL_LINE_WIDTH
-			// IMPORTANT: We MUST allocate a minimum of 16 floats in our FloatBuffer in LWJGL, we CANNOT just get a FloatBuffer with 1 float!
-			// ALSO: glPushAttrib(GL_LINE_BIT); /* do stuff */ glPopAttrib(); should work instead of this in theory - but LWJGL fails with 'function not supported'.
-			glGetFloatv(GL_LINE_WIDTH, lineWidthFloatBuffer);
-	
-			/// Set the GL_LINE_WIDTH to be the width requested, as passed to the constructor
-			glLineWidth(lineWidth);
-	
-			// 	Draw the axis lines
-			glDrawArrays(GL_LINES, 0, NUM_VERTICES);
-	
-			// Reset the line width to the previous value
-			glLineWidth( lineWidthFloatBuffer.get(0) );
+		// Provide the projection matrix uniform
+		glUniformMatrix4fv(lineShaderProgram.uniform("mvpMatrix"), false, mvpMatrixFloatBuffer);
+
+		// Store the current GL_LINE_WIDTH
+		// IMPORTANT: We MUST allocate a minimum of 16 floats in our FloatBuffer in LWJGL, we CANNOT just get a FloatBuffer with 1 float!
+		// ALSO: glPushAttrib(GL_LINE_BIT); /* do stuff */ glPopAttrib(); should work instead of this in theory - but LWJGL fails with 'function not supported'.
+		glGetFloatv(GL_LINE_WIDTH, lineWidthFloatBuffer);
+
+		/// Set the GL_LINE_WIDTH to be the width requested, as passed to the constructor
+		glLineWidth(lineWidth);
+
+		// 	Draw the axis lines
+		glDrawArrays(GL_LINES, 0, NUM_VERTICES);
+
+		// Reset the line width to the previous value
+		glLineWidth( lineWidthFloatBuffer.get(0) );
 
 		// Unbind from VBO
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -228,6 +205,28 @@ public class Line2D
 	public void draw(Vec2f p1, Vec2f p2, Colour4f colour, float lineWidth, Mat4f mvpMatrix)
 	{
 		this.draw(p1, p2, colour, colour,  lineWidth, mvpMatrix);
+	}
+	
+	private static void setLineData(Vec2f p1, Vec2f p2, Colour4f c1, Colour4f c2) {
+		// First vertex x/y location
+		lineData[0] = p1.x;
+		lineData[1] = p1.y;
+
+		// First vertex colour
+		lineData[2]  = c1.r;
+		lineData[3]  = c1.g;
+		lineData[4]  = c1.b;
+		lineData[5]  = c1.a;
+
+		// Second vertex x/y location
+		lineData[6]  = p2.x;
+		lineData[7]  = p2.y;
+
+		// Second vertex colour
+		lineData[8]  = c2.r;
+		lineData[9]  = c2.g;
+		lineData[10] = c2.b;
+		lineData[11] = c2.a;		
 	}
 	
 } // End of Line2D class

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line2D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line2D.java
@@ -31,16 +31,16 @@ public class Line2D
 	private static final int COMPONENT_COUNT = VERTEX_COMPONENTS + COLOUR_COMPONENTS;
 
 	// Flag used so that we only initialise the shader once
-	private static boolean shaderInitialised = false;
+	private boolean shaderInitialised = false;
 
 	/** Static ShaderProgram shared across all Line2D instances. */
-	private static ShaderProgram lineShaderProgram;
+	private ShaderProgram lineShaderProgram;
 
 	/** Static FloatBuffer to hold the ModelViewProjection matrix - shared across all line 2D instances and updated for each line drawn. */
-	private static FloatBuffer mvpMatrixFloatBuffer;
+	private FloatBuffer mvpMatrixFloatBuffer;
 
 	/** GLSL version 330 fragment shader code. */	
-	private static String vertexShaderSource =
+	private static final String vertexShaderSource =
 			"#version 330"                                                                      + Utils.NEW_LINE +
 			"in vec2 vertexLocation; // Incoming vertex attribute"                              + Utils.NEW_LINE +
 			"in vec4 vertexColour;   // Incoming colour value"                                  + Utils.NEW_LINE +
@@ -52,7 +52,7 @@ public class Line2D
 			"}";
 
 	/** GLSL version 330 fragment shader code. */
-	private static String fragmentShaderSource =
+	private static final String fragmentShaderSource =
 			"#version 330"                                                  + Utils.NEW_LINE +
 			"in vec4 fragColour;     // Incoming colour from vertex shader" + Utils.NEW_LINE +
 			"out vec4 vOutputColour; // Outgoing colour value"              + Utils.NEW_LINE +
@@ -60,13 +60,11 @@ public class Line2D
 			"	vOutputColour = fragColour;"                                + Utils.NEW_LINE +
 			"}";
 
-	// ----- Non-Static Properties -----
-
-	private static int         lineVaoId;             // The Vertex Array Object ID which holds our shader attributes
-	private static int         lineVertexBufferId;    // The id of the vertex buffer containing the grid vertex data
-	private static float[]     lineData;              // Array of floats used to draw the grid
-	private static FloatBuffer vertexFloatBuffer;     // Vertex buffer to hold the gridArray vertex data
-	private static FloatBuffer lineWidthFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
+	private int         lineVaoId;             // The Vertex Array Object ID which holds our shader attributes
+	private int         lineVertexBufferId;    // The id of the vertex buffer containing the grid vertex data
+	private float[]     lineData;              // Array of floats used to draw the grid
+	private FloatBuffer vertexFloatBuffer;     // Vertex buffer to hold the gridArray vertex data
+	private FloatBuffer lineWidthFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
 
 	/** Constructor */
 	public Line2D()
@@ -86,10 +84,6 @@ public class Line2D
 			lineShaderProgram = new ShaderProgram();
 
 			lineShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
-
-			// We no longer need the shader sources
-			vertexShaderSource   = null;
-			fragmentShaderSource = null;
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line2D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line2D.java
@@ -130,7 +130,7 @@ public class Line2D
                                                                      GL_FLOAT,  // Data type
                                                                          true,  // Normalised? Colour values are between 0.0 and 1.0, so yes!
                                                 COMPONENT_COUNT * Float.BYTES,  // Stride
-                                             VERTEX_COMPONENTS * Float.BYTES);  // Offset
+                                        (long)VERTEX_COMPONENTS * Float.BYTES);  // Offset
 			
 			// Unbind VBO
 			glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line2D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line2D.java
@@ -40,7 +40,7 @@ public class Line2D
 	private FloatBuffer mvpMatrixFloatBuffer;
 
 	/** GLSL version 330 fragment shader code. */	
-	private static final String vertexShaderSource =
+	private static final String VERTEX_SHADER_SOURCE =
 			"#version 330"                                                                      + Utils.NEW_LINE +
 			"in vec2 vertexLocation; // Incoming vertex attribute"                              + Utils.NEW_LINE +
 			"in vec4 vertexColour;   // Incoming colour value"                                  + Utils.NEW_LINE +
@@ -52,7 +52,7 @@ public class Line2D
 			"}";
 
 	/** GLSL version 330 fragment shader code. */
-	private static final String fragmentShaderSource =
+	private static final String FRAGMENT_SHADER_SOURCE =
 			"#version 330"                                                  + Utils.NEW_LINE +
 			"in vec4 fragColour;     // Incoming colour from vertex shader" + Utils.NEW_LINE +
 			"out vec4 vOutputColour; // Outgoing colour value"              + Utils.NEW_LINE +
@@ -83,7 +83,7 @@ public class Line2D
 
 			lineShaderProgram = new ShaderProgram();
 
-			lineShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
+			lineShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line3D.java
@@ -29,15 +29,15 @@ public class Line3D
 	private static final int VERTEX_COMPONENTS = 3;
 
 	// Flag used so that we only initialise the shader once
-	private static boolean shaderInitialised = false;
+	private boolean shaderInitialised = false;
 
 	// Declare our shader program and the float buffer for our MVP matrix
-	private static ShaderProgram shaderProgram;
-	private static FloatBuffer mvpMatrixFloatBuffer;
-	private static FloatBuffer colourFloatBuffer;
+	private ShaderProgram shaderProgram;
+	private FloatBuffer mvpMatrixFloatBuffer;
+	private FloatBuffer colourFloatBuffer;
 
 	//Define our vertex and fragement shader GLSL source code
-	private static String vertexShaderSource =
+	private static final String vertexShaderSource =
 			"#version 330"                                                         + Utils.NEW_LINE +
 			"in vec4 vertexLocation; // Incoming vertex attribute"                 + Utils.NEW_LINE +
 			"out vec4 fragColour;    // Outgoing colour value"                     + Utils.NEW_LINE +
@@ -46,7 +46,7 @@ public class Line3D
 			"	gl_Position = mvpMatrix * vertexLocation; // Project our geometry" + Utils.NEW_LINE +
 			"}";
 
-	private static String fragmentShaderSource =
+	private static final String fragmentShaderSource =
 			"#version 330"                                     + Utils.NEW_LINE +
 			"out vec4 vOutputColour; // Outgoing colour value" + Utils.NEW_LINE +
 			"uniform vec4 colour;"                             + Utils.NEW_LINE +
@@ -54,13 +54,11 @@ public class Line3D
 			"	vOutputColour = colour;"                       + Utils.NEW_LINE +
 			"}";
 
-	// ----- Non-Static Properties -----
-
-	private static int         vaoId;                // The Vertex Array Object ID which holds our shader attributes
-	private static int         vboId;                // The id of the vertex buffer containing the grid vertex data
-	private static float[]     lineData;             // Array of floats used to draw the line
-	private static FloatBuffer vertexFloatBuffer;    // Vertex buffer to hold the gridArray vertex data
-	private static FloatBuffer lineWidthFloatBuffer; // Vertex buffer to hold the gridArray vertex data
+	private int         vaoId;                // The Vertex Array Object ID which holds our shader attributes
+	private int         vboId;                // The id of the vertex buffer containing the grid vertex data
+	private float[]     lineData;             // Array of floats used to draw the line
+	private FloatBuffer vertexFloatBuffer;    // Vertex buffer to hold the gridArray vertex data
+	private FloatBuffer lineWidthFloatBuffer; // Vertex buffer to hold the gridArray vertex data
 
 	/** Constructor */
 	public Line3D()
@@ -79,10 +77,6 @@ public class Line3D
 
 			shaderProgram = new ShaderProgram();
 			shaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
-
-			// We no longer need the shader sources now we have a compiled shader
-			vertexShaderSource   = null;
-			fragmentShaderSource = null;
 
 			// Add the shader attributes and uniforms
 			shaderProgram.addAttribute("vertexLocation");

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line3D.java
@@ -119,7 +119,7 @@ public class Line3D
 			glBindVertexArray(0);
 			
 			// Finally, instantiate our shaderInitialised Boolean so we don't perform this shader setup again
-			shaderInitialised = new Boolean(true);
+			shaderInitialised = true;
 		}
 	}
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line3D.java
@@ -28,13 +28,10 @@ public class Line3D
 	private static final int NUM_VERTICES      = 2;
 	private static final int VERTEX_COMPONENTS = 3;
 
-	// Flag used so that we only initialise the shader once
-	private boolean shaderInitialised = false;
-
 	// Declare our shader program and the float buffer for our MVP matrix
-	private ShaderProgram shaderProgram;
-	private FloatBuffer mvpMatrixFloatBuffer;
-	private FloatBuffer colourFloatBuffer;
+	private static ShaderProgram shaderProgram;
+	private static FloatBuffer mvpMatrixFloatBuffer;
+	private static FloatBuffer colourFloatBuffer;
 
 	//Define our vertex and fragement shader GLSL source code
 	private static final String VERTEX_SHADER_SOURCE =
@@ -54,67 +51,65 @@ public class Line3D
 			"	vOutputColour = colour;"                       + Utils.NEW_LINE +
 			"}";
 
-	private int         vaoId;                // The Vertex Array Object ID which holds our shader attributes
-	private int         vboId;                // The id of the vertex buffer containing the grid vertex data
-	private float[]     lineData;             // Array of floats used to draw the line
-	private FloatBuffer vertexFloatBuffer;    // Vertex buffer to hold the gridArray vertex data
-	private FloatBuffer lineWidthFloatBuffer; // Vertex buffer to hold the gridArray vertex data
+	private static int         vaoId;                // The Vertex Array Object ID which holds our shader attributes
+	private static int         vboId;                // The id of the vertex buffer containing the grid vertex data
+	private static float[]     lineData;             // Array of floats used to draw the line
+	private static FloatBuffer vertexFloatBuffer;    // Vertex buffer to hold the gridArray vertex data
+	private static FloatBuffer lineWidthFloatBuffer; // Vertex buffer to hold the gridArray vertex data
+	
+	static {
+		// Allocate memory for arrays and buffers
+		lineData = new float[NUM_VERTICES * VERTEX_COMPONENTS];
+		vertexFloatBuffer    = Utils.createFloatBuffer(NUM_VERTICES * VERTEX_COMPONENTS);
+		mvpMatrixFloatBuffer = Utils.createFloatBuffer(16);
+		lineWidthFloatBuffer = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 1 float
+		colourFloatBuffer    = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 4 floats
+
+		// ----- Shader program setup -----
+
+		shaderProgram = new ShaderProgram();
+		shaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
+
+		// Add the shader attributes and uniforms
+		shaderProgram.addAttribute("vertexLocation");
+		shaderProgram.addUniform("mvpMatrix");
+		shaderProgram.addUniform("colour");
+
+		// Get an id for the Vertex Array Object (VAO) and bind to it
+		vaoId = glGenVertexArrays();
+		glBindVertexArray(vaoId);
+
+		// Generate an id for our Vertex Buffer Object (VBO) and bind to it
+		vboId = glGenBuffers();
+		glBindBuffer(GL_ARRAY_BUFFER, vboId);
+
+		// Place the location data into the VBO...
+		glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
+
+		// ...and specify the data format.
+		glVertexAttribPointer(shaderProgram.attribute("vertexLocation"), // Vertex location attribute index
+				                                      VERTEX_COMPONENTS, // Number of normal components per vertex
+				                                               GL_FLOAT, // Data type
+				                                                  false, // Normalised?
+				                        VERTEX_COMPONENTS * Float.BYTES, // Stride
+				                                                     0); // Offset
+			
+	
+		// Unbind VBO
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+		// Enable the vertex attributes
+		glEnableVertexAttribArray(shaderProgram.attribute("vertexLocation"));
+
+		// Unbind our from our VAO, saving all settings
+		glBindVertexArray(0);
+		
+	}
 
 	/** Constructor */
 	public Line3D()
 	{
-		// If this is the first grid we're creating then do the shader setup
-		if (!shaderInitialised)
-		{	
-			// Allocate memory for arrays and buffers
-			lineData = new float[NUM_VERTICES * VERTEX_COMPONENTS];
-			vertexFloatBuffer    = Utils.createFloatBuffer(NUM_VERTICES * VERTEX_COMPONENTS);
-			mvpMatrixFloatBuffer = Utils.createFloatBuffer(16);
-			lineWidthFloatBuffer = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 1 float
-			colourFloatBuffer    = Utils.createFloatBuffer(16); // Minimum size is 16, even though we only want to store 4 floats
-
-			// ----- Shader program setup -----
-
-			shaderProgram = new ShaderProgram();
-			shaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
-
-			// Add the shader attributes and uniforms
-			shaderProgram.addAttribute("vertexLocation");
-			shaderProgram.addUniform("mvpMatrix");
-			shaderProgram.addUniform("colour");
-
-			// Get an id for the Vertex Array Object (VAO) and bind to it
-			vaoId = glGenVertexArrays();
-			glBindVertexArray(vaoId);
-
-				// Generate an id for our Vertex Buffer Object (VBO) and bind to it
-				vboId = glGenBuffers();
-				glBindBuffer(GL_ARRAY_BUFFER, vboId);
-
-					// Place the location data into the VBO...
-					glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
-		
-					// ...and specify the data format.
-					glVertexAttribPointer(shaderProgram.attribute("vertexLocation"), // Vertex location attribute index
-							                                      VERTEX_COMPONENTS, // Number of normal components per vertex
-							                                               GL_FLOAT, // Data type
-							                                                  false, // Normalised?
-							                        VERTEX_COMPONENTS * Float.BYTES, // Stride
-							                                                     0); // Offset
-					
-			
-				// Unbind VBO
-				glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-				// Enable the vertex attributes
-				glEnableVertexAttribArray(shaderProgram.attribute("vertexLocation"));
-
-			// Unbind our from our VAO, saving all settings
-			glBindVertexArray(0);
-			
-			// Finally, instantiate our shaderInitialised Boolean so we don't perform this shader setup again
-			shaderInitialised = true;
-		}
+		//
 	}
 
 	/**
@@ -128,15 +123,7 @@ public class Line3D
 	 */
 	public void draw(Vec3f p1, Vec3f p2, Colour4f colour, float lineWidth, Mat4f mvpMatrix)
 	{
-		// Point 1 x/y/z
-		lineData[0] = p1.x;
-		lineData[1] = p1.y;
-		lineData[2] = p1.z;
-		
-		// Point 2 x/y/z
-		lineData[3] = p2.x;
-		lineData[4] = p2.y;
-		lineData[5] = p2.z;
+		setLineData(p1, p2);
 		
 		// Transfer the line, matrix and colour data into the float buffers
 		vertexFloatBuffer.put( lineData );
@@ -150,27 +137,27 @@ public class Line3D
 		shaderProgram.use();
 		glBindVertexArray(vaoId);
 
-			// Bind to the vertex buffer object (VBO) and place the new data into it
-			glBindBuffer(GL_ARRAY_BUFFER, vboId);
-			glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
-	
-			// Provide the projection matrix uniform to our shader
-			glUniformMatrix4fv(shaderProgram.uniform("mvpMatrix"), false, mvpMatrixFloatBuffer);
-			glUniform4fv(shaderProgram.uniform("colour"), colourFloatBuffer);
-	
-			// Store the current GL_LINE_WIDTH
-			// IMPORTANT: We MUST allocate a minimum of 16 floats in our FloatBuffer in LWJGL, we CANNOT just get a FloatBuffer with 1 float!
-			// ALSO: glPushAttrib(GL_LINE_BIT); /* do stuff */ glPopAttrib(); should work instead of this in theory - but LWJGL fails with 'function not supported'.
-			glGetFloatv(GL_LINE_WIDTH, lineWidthFloatBuffer);
-	
-			/// Set the line width to be the width requested
-			glLineWidth(lineWidth);
-			
-			// 	Draw the line
-			glDrawArrays(GL_LINES, 0, NUM_VERTICES);
-	
-			// Restore the previous GL_LINE_WIDTH
-			glLineWidth( lineWidthFloatBuffer.get(0) );
+		// Bind to the vertex buffer object (VBO) and place the new data into it
+		glBindBuffer(GL_ARRAY_BUFFER, vboId);
+		glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
+
+		// Provide the projection matrix uniform to our shader
+		glUniformMatrix4fv(shaderProgram.uniform("mvpMatrix"), false, mvpMatrixFloatBuffer);
+		glUniform4fv(shaderProgram.uniform("colour"), colourFloatBuffer);
+
+		// Store the current GL_LINE_WIDTH
+		// IMPORTANT: We MUST allocate a minimum of 16 floats in our FloatBuffer in LWJGL, we CANNOT just get a FloatBuffer with 1 float!
+		// ALSO: glPushAttrib(GL_LINE_BIT); /* do stuff */ glPopAttrib(); should work instead of this in theory - but LWJGL fails with 'function not supported'.
+		glGetFloatv(GL_LINE_WIDTH, lineWidthFloatBuffer);
+
+		/// Set the line width to be the width requested
+		glLineWidth(lineWidth);
+		
+		// 	Draw the line
+		glDrawArrays(GL_LINES, 0, NUM_VERTICES);
+
+		// Restore the previous GL_LINE_WIDTH
+		glLineWidth( lineWidthFloatBuffer.get(0) );
 
 		// Unbind from VBO & VAO, then disable our shader
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -190,6 +177,18 @@ public class Line3D
 	public void draw(Vec3f p1, Vec3f p2, float lineWidth, Mat4f mvpMatrix)
 	{
 		draw(p1, p2, Line3D.white, lineWidth, mvpMatrix);
+	}
+	
+	private static void setLineData(Vec3f p1, Vec3f p2) {
+		// Point 1 x/y/z
+		lineData[0] = p1.x;
+		lineData[1] = p1.y;
+		lineData[2] = p1.z;
+		
+		// Point 2 x/y/z
+		lineData[3] = p2.x;
+		lineData[4] = p2.y;
+		lineData[5] = p2.z;
 	}
 	
 } // End of Line3D class

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Line3D.java
@@ -37,7 +37,7 @@ public class Line3D
 	private FloatBuffer colourFloatBuffer;
 
 	//Define our vertex and fragement shader GLSL source code
-	private static final String vertexShaderSource =
+	private static final String VERTEX_SHADER_SOURCE =
 			"#version 330"                                                         + Utils.NEW_LINE +
 			"in vec4 vertexLocation; // Incoming vertex attribute"                 + Utils.NEW_LINE +
 			"out vec4 fragColour;    // Outgoing colour value"                     + Utils.NEW_LINE +
@@ -46,7 +46,7 @@ public class Line3D
 			"	gl_Position = mvpMatrix * vertexLocation; // Project our geometry" + Utils.NEW_LINE +
 			"}";
 
-	private static final String fragmentShaderSource =
+	private static final String FRAGMENT_SHADER_SOURCE =
 			"#version 330"                                     + Utils.NEW_LINE +
 			"out vec4 vOutputColour; // Outgoing colour value" + Utils.NEW_LINE +
 			"uniform vec4 colour;"                             + Utils.NEW_LINE +
@@ -76,7 +76,7 @@ public class Line3D
 			// ----- Shader program setup -----
 
 			shaderProgram = new ShaderProgram();
-			shaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
+			shaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
 
 			// Add the shader attributes and uniforms
 			shaderProgram.addAttribute("vertexLocation");

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Model.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Model.java
@@ -29,6 +29,9 @@ import au.edu.federation.utils.Vec3i;
 public class Model
 {
 	private static boolean VERBOSE = false;
+	private static final String NUMBER_OF_VERTICES_LOG = "Number of vertices in data array: %d (%d bytes)";
+	private static final String NUMBER_OF_NORMALS_LOG = "Number of normals  in data array: %d (%d bytes)";
+	private static final String WRONG_COMPONENT_COUNT_LOG = "Found %s data with wrong component count at line number: %d - Skipping!";
 	
 	// ---------- Private Properties ----------
 
@@ -508,7 +511,7 @@ public class Model
 					String[] token = line.split("\\s+");
 
 					// If the first token is "v", then we're dealing with vertex data
-					if ( token[0].equalsIgnoreCase("v") )
+					if ( "v".equalsIgnoreCase(token[0]) )
 					{
 						// As long as there's 4 tokens on the line...
 						if (token.length == 4)
@@ -527,11 +530,11 @@ public class Model
 						else // If we got vertex data without 3 components - whine!
 						{
 							loadedCleanly = false;
-							System.out.println( "Found vertex data with wrong component count at line number: " + lineCount + " - Skipping!");
+							System.out.printf(WRONG_COMPONENT_COUNT_LOG,"vertex",lineCount);
 						}
 
 					} 
-					else if ( token[0].equalsIgnoreCase("vn") ) // If the first token is "vn", then we're dealing with a vertex normal
+					else if ( "vn".equalsIgnoreCase(token[0]) ) // If the first token is "vn", then we're dealing with a vertex normal
 					{
 						// As long as there's 4 tokens on the line...
 						if (token.length == 4)
@@ -550,7 +553,7 @@ public class Model
 						else // If we got normal data without 3 components - whine!
 						{
 							loadedCleanly = false;
-							System.out.println( "Found normal data with wrong component count at line number: " + lineCount + " - Skipping!") ;
+							System.out.printf(WRONG_COMPONENT_COUNT_LOG,"normal",lineCount);
 						}
 
 					} // End of vertex line parsing
@@ -560,7 +563,7 @@ public class Model
 					// Note: Faces can be described in two ways - we can have data like 'f 123 456 789' which means that the face is comprised
 					// of vertex 123, vertex 456 and vertex 789. Or, we have have data like f 123//111 456//222 789//333 which means that
 					// the face is comprised of vertex 123 using normal 111, vertex 456 using normal 222 and vertex 789 using normal 333.
-					else if ( token[0].equalsIgnoreCase("f") )
+					else if ( "f".equalsIgnoreCase(token[0]) )
 					{
 						// Check if there's a double-slash in the line
 						int pos = line.indexOf("//");
@@ -654,7 +657,7 @@ public class Model
 						else // If we got face data without 3 components - whine!
 						{
 							loadedCleanly = false;
-							System.out.println( "Found face data with wrong component count at line number: " + lineCount + " - Skipping!");
+							System.out.printf(WRONG_COMPONENT_COUNT_LOG,"face",lineCount);
 						}
 
 					} // End of if token is "f" (i.e. face indices)
@@ -737,7 +740,7 @@ public class Model
 
 			// Print a summary of the vertex data
 			if (VERBOSE) { 
-			  System.out.println( "Number of vertices in data array: " + numVertices + " (" + getVertexDataSizeBytes() + " bytes)"); 
+			  System.out.printf( NUMBER_OF_VERTICES_LOG, numVertices, getVertexDataSizeBytes()); 
 			}
 		}
 		// If we have vertices AND faces BUT NOT normals...
@@ -822,8 +825,8 @@ public class Model
 
 			if (VERBOSE)
 			{
-				System.out.println( "Number of vertices in data array: " + numVertices + " (" + getVertexDataSizeBytes() + " bytes)");
-				System.out.println( "Number of normals  in data array: " + numNormals  + " (" + getNormalDataSizeBytes() + " bytes)");
+				System.out.printf( NUMBER_OF_VERTICES_LOG, numVertices, getVertexDataSizeBytes());
+				System.out.printf( NUMBER_OF_NORMALS_LOG, numNormals, getNormalDataSizeBytes());
 			}
 		}
 		// If we have vertices AND faces AND normals AND normalIndices...
@@ -911,8 +914,8 @@ public class Model
 
 			if (VERBOSE)
 			{
-				System.out.println( "Number of vertices in data array: " + numVertices + " (" + getVertexDataSizeBytes() + " bytes)");
-				System.out.println( "Number of normals  in data array: " + numNormals  + " (" + getNormalDataSizeBytes() + " bytes)");
+				System.out.printf( NUMBER_OF_VERTICES_LOG, numVertices, getVertexDataSizeBytes());
+				System.out.printf( NUMBER_OF_NORMALS_LOG, numNormals, getNormalDataSizeBytes());
 			}
 		}
 		else

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Model.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Model.java
@@ -2,7 +2,6 @@ package au.edu.federation.caliko.visualisation;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -34,10 +33,10 @@ public class Model
 	// ---------- Private Properties ----------
 
 	// These are the models values as read from the file - they are not the final, consolidated model data
-	private List<Vec3f> vertices      = new ArrayList<Vec3f>();
-	private List<Vec3f> normals       = new ArrayList<Vec3f>();
-	private List<Vec3i> normalIndices = new ArrayList<Vec3i>();
-	private List<Vec3i> faces         = new ArrayList<Vec3i>();
+	private List<Vec3f> vertices      = new ArrayList<>();
+	private List<Vec3f> normals       = new ArrayList<>();
+	private List<Vec3i> normalIndices = new ArrayList<>();
+	private List<Vec3i> faces         = new ArrayList<>();
 	//ArrayList texCoords = new ArrayList<Vector>();
 
 	// The vertexData and normalData arrays are the final consolidated data which we can draw with.
@@ -47,8 +46,8 @@ public class Model
 	// vertices / normals as each vertex / normal may be used more than once in the model - the end result of this is that
 	// the vertexData and normalData will likely be larger than the 'as-read-from-file' vertices and normals arrays because
 	// of this duplication of values from the face data.
-	private List<Float> vertexData = new ArrayList<Float>();
-	private List<Float> normalData = new ArrayList<Float>();
+	private List<Float> vertexData = new ArrayList<>();
+	private List<Float> normalData = new ArrayList<>();
 	//ArrayList texCoordData = new ArrayList<Vector>();
 
 	// Counters to keep track of how many vertices, normals, normal indices, texture coordinates and faces
@@ -96,7 +95,9 @@ public class Model
 			{
 				//model.vertexData.add(f)
 			}
-			for ( Float f : sourceModel.getVertexData() ) { model.vertexData.add(f); }
+			for ( Float f : sourceModel.getVertexData() ) { 
+			  model.vertexData.add(f); 
+			}
 		}
 		else // ...or abort if we have no vertices to copy!
 		{
@@ -106,15 +107,21 @@ public class Model
 		// If the source model has normals then copy them across to the clone...
 		if (model.numNormals > 0)
 		{
-			for ( Float f : sourceModel.getNormalData() ) { model.normalData.add(f); }
+			for ( Float f : sourceModel.getNormalData() ) { 
+			  model.normalData.add(f); 
+			}
 		}
 		else // ...or (potentially) inform the user if they are no normals. This is not necessarily a deal breaker though, so we don't abort.
 		{
-			if (VERBOSE) { System.out.println( "Model created using clone method has 0 normals - continuing...");	}
+			if (VERBOSE) { 
+			  System.out.println( "Model created using clone method has 0 normals - continuing...");	
+			}
 		}
 
 		// Display final status if appropriate
-		if (VERBOSE) { System.out.println( "Model successfully cloned."); }
+		if (VERBOSE) { 
+		  System.out.println( "Model successfully cloned."); 
+		}
 
 		// Finally, return our cloned model
 		return model;
@@ -143,8 +150,12 @@ public class Model
 		// Did we load the file without errors?
 		if (VERBOSE)
 		{
-			if (modelLoadedCleanly) { System.out.println("Model loaded cleanly.");     }
-			else                    { System.out.println("Model loaded with errors."); }
+			if (modelLoadedCleanly) { 
+			  System.out.println("Model loaded cleanly.");     
+			}
+			else { 
+			  System.out.println("Model loaded with errors."); 
+			}
 		}
 
 		// Do we have vertices? If not then this is a non-recoverable error and we abort!
@@ -153,9 +164,15 @@ public class Model
 			if (VERBOSE)
 			{
 				System.out.println("Model vertex count: " + getNumVertices() ); 
-				if ( hasFaces()         ) { System.out.println( "Model face         count: " + getNumFaces()         ); }
-				if ( hasNormals()       ) { System.out.println( "Model normal       count: " + getNumNormals()       ); }
-				if ( hasNormalIndices() ) {	System.out.println( "Model normal index count: " + getNumNormalIndices() ); }
+				if ( hasFaces()         ) { 
+				  System.out.println( "Model face         count: " + getNumFaces()         );
+				}
+				if ( hasNormals()       ) { 
+				  System.out.println( "Model normal       count: " + getNumNormals()       ); 
+				}
+				if ( hasNormalIndices() ) {	
+				  System.out.println( "Model normal index count: " + getNumNormalIndices() ); 
+				}
 			}
 		}
 		else { throw new RuntimeException("Model has no vertices."); }
@@ -209,7 +226,9 @@ public class Model
 		float[] vertexFloatArray = new float[numVertexFloats];
 
 		// Loop over each item in the list, setting it to the appropriate element in the array
-		for (int loop = 0; loop < numVertexFloats; loop++) { vertexFloatArray[loop] = vertexData.get(loop); }
+		for (int loop = 0; loop < numVertexFloats; loop++) { 
+		  vertexFloatArray[loop] = vertexData.get(loop); 
+		}
 
 		// Finally, return the float array
 		return vertexFloatArray;
@@ -229,7 +248,9 @@ public class Model
 		float[] normalFloatArray = new float[numNormalFloats];
 
 		// Loop over each item in the list, setting it to the appropriate element in the array
-		for (int loop = 0; loop < numNormalFloats; loop++) { normalFloatArray[loop] = normalData.get(loop);	}
+		for (int loop = 0; loop < numNormalFloats; loop++) { 
+		  normalFloatArray[loop] = normalData.get(loop);	
+		}
 
 		// Finally, return the float array
 		return normalFloatArray;
@@ -298,7 +319,9 @@ public class Model
 	public void scale(float scale)
 	{
 		int numVerts = vertexData.size();
-		for (int loop = 0; loop < numVerts; ++loop) { vertexData.set(loop, vertexData.get(loop) * scale); }
+		for (int loop = 0; loop < numVerts; ++loop) { 
+		  vertexData.set(loop, vertexData.get(loop) * scale); 
+		}
 	}
 
 	/**
@@ -309,7 +332,9 @@ public class Model
 	public void scaleX(float scale)
 	{
 		int numVerts = vertexData.size();
-		for (int loop = 0; loop < numVerts; loop += 3) { vertexData.set( loop, vertexData.get(loop) * scale); }
+		for (int loop = 0; loop < numVerts; loop += 3) { 
+		  vertexData.set( loop, vertexData.get(loop) * scale); 
+		}
 	}
 	
 	/**
@@ -320,7 +345,9 @@ public class Model
 	public void scaleY(float scale)
 	{
 		int numVerts = vertexData.size();
-		for (int loop = 1; loop < numVerts; loop += 3) { vertexData.set( loop, vertexData.get(loop) * scale); }
+		for (int loop = 1; loop < numVerts; loop += 3) { 
+		  vertexData.set( loop, vertexData.get(loop) * scale); 
+		}
 	}
 	
 	/**
@@ -331,7 +358,9 @@ public class Model
 	public void scaleZ(float scale)
 	{
 		int numVerts = vertexData.size();
-		for (int loop = 2; loop < numVerts; loop += 3) { vertexData.set( loop, vertexData.get(loop) * scale); }
+		for (int loop = 2; loop < numVerts; loop += 3) { 
+		  vertexData.set( loop, vertexData.get(loop) * scale); 
+		}
 	}
 
 	/**
@@ -362,7 +391,11 @@ public class Model
 	}
 	
 	/** Print out the vertices of this model. */
-	public void printVertices() { for (Vec3f v : vertices) { System.out.println( "Vertex: " + v.toString() );	} }
+	public void printVertices() { 
+	  for (Vec3f v : vertices) { 
+	    System.out.println( "Vertex: " + v.toString() );	
+	  }
+	}
 
 	/**
 	 * Print out the vertex normal data for this model.
@@ -371,7 +404,9 @@ public class Model
 	 */
 	public void printNormals()
 	{
-		for (Vec3f n : normals)	{ System.out.println( "Normal: " + n.toString() ); }
+		for (Vec3f n : normals)	{ 
+		  System.out.println( "Normal: " + n.toString() ); 
+		}
 	}
 
 	/**
@@ -381,7 +416,9 @@ public class Model
 	 */
 	public void printFaces()
 	{
-		for (Vec3i face : faces) { System.out.println( "Face: " + face.toString() ); }
+		for (Vec3i face : faces) { 
+		  System.out.println( "Face: " + face.toString() ); 
+		}
 	}
 
 	/**
@@ -427,14 +464,14 @@ public class Model
 	private boolean loadModel(String filename)
 	{
 		// Initialise lists
-		vertices      = new ArrayList<Vec3f>();
-		normals       = new ArrayList<Vec3f>();
-		normalIndices = new ArrayList<Vec3i>();
-		faces         = new ArrayList<Vec3i>();
+		vertices      = new ArrayList<>();
+		normals       = new ArrayList<>();
+		normalIndices = new ArrayList<>();
+		faces         = new ArrayList<>();
 		//texCoords = new ArrayList<Vec2f();
 
-		vertexData      = new ArrayList<Float>();
-		normalData      = new ArrayList<Float>();
+		vertexData      = new ArrayList<>();
+		normalData      = new ArrayList<>();
 		//texCoordData      = new ArrayList<Vec2f>();
 
 		// Our vectors of attributes are initially empty
@@ -477,9 +514,9 @@ public class Model
 						if (token.length == 4)
 						{
 							// ...get the remaining 3 tokens as the x/y/z float values...
-							float x = Float.valueOf(token[1]);
-							float y = Float.valueOf(token[2]);
-							float z = Float.valueOf(token[3]);
+							float x = Float.parseFloat(token[1]);
+							float y = Float.parseFloat(token[2]);
+							float z = Float.parseFloat(token[3]);
 
 							// ... and push them into the vertices vector ...
 							vertices.add( new Vec3f(x, y, z) );
@@ -500,9 +537,9 @@ public class Model
 						if (token.length == 4)
 						{
 							// ...get the remaining 3 tokens as the x/y/z normal float values...
-							float normalX = Float.valueOf(token[1]);
-							float normalY = Float.valueOf(token[2]);
-							float normalZ = Float.valueOf(token[3]);
+							float normalX = Float.parseFloat(token[1]);
+							float normalY = Float.parseFloat(token[2]);
+							float normalZ = Float.parseFloat(token[3]);
 
 							// ... and push them into the normals vector ...
 							normals.add( new Vec3f(normalX, normalY, normalZ) );
@@ -532,9 +569,9 @@ public class Model
 						if ( (token.length == 4) && (pos == -1) )
 						{
 							// ...get the face vertex numbers as ints ...
-							int v1  = Integer.valueOf(token[1]);
-							int v2  = Integer.valueOf(token[2]);
-							int v3  = Integer.valueOf(token[3]);
+							int v1  = Integer.parseInt(token[1]);
+							int v2  = Integer.parseInt(token[2]);
+							int v3  = Integer.parseInt(token[3]);
 
 							// ... and push them into the faces vector ...
 							faces.add( new Vec3i(v1, v2, v3) );
@@ -553,7 +590,7 @@ public class Model
 							String faceToken1 = token[1].substring(0, faceEndPos);
 
 							// Convert face token value to int
-							int ft1 = Integer.valueOf(faceToken1);
+							int ft1 = Integer.parseInt(faceToken1);
 
 							// Mark the start of our next subtoken
 							int nextTokenStartPos = faceEndPos + 2;
@@ -562,7 +599,7 @@ public class Model
 							String normalToken1 = token[1].substring(nextTokenStartPos);
 
 							// Convert normal token value to int
-							int nt1 = Integer.valueOf(normalToken1);
+							int nt1 = Integer.parseInt(normalToken1);
 
 							// ----- Get the 2nd of three tokens as a String -----
 
@@ -573,7 +610,7 @@ public class Model
 							String faceToken2 = token[2].substring(0, faceEndPos);
 
 							// Convert face token value to int
-							int ft2 = Integer.valueOf(faceToken2);
+							int ft2 = Integer.parseInt(faceToken2);
 
 							// Mark the start of our next subtoken
 							nextTokenStartPos = faceEndPos + 2;
@@ -582,7 +619,7 @@ public class Model
 							String normalToken2 = token[2].substring(nextTokenStartPos);
 
 							// Convert normal token value to int
-							int nt2 = Integer.valueOf(normalToken2);
+							int nt2 = Integer.parseInt(normalToken2);
 
 							// ----- Get the 3rd of three tokens as a String -----
 
@@ -593,7 +630,7 @@ public class Model
 							String faceToken3 = token[3].substring(0, faceEndPos);
 
 							// Convert face token value to int
-							int ft3 = Integer.valueOf(faceToken3);
+							int ft3 = Integer.parseInt(faceToken3);
 
 							// Mark the start of our next subtoken
 							nextTokenStartPos = faceEndPos + 2;
@@ -602,7 +639,7 @@ public class Model
 							String normalToken3 = token[3].substring(nextTokenStartPos);
 
 							// Convert normal token value to int
-							int nt3 = Integer.valueOf(normalToken3);
+							int nt3 = Integer.parseInt(normalToken3);
 
 
 							// Finally, add the face to the faces array list and increment the face count...
@@ -675,12 +712,16 @@ public class Model
 	 */
 	private void setupData()
 	{
-		if (VERBOSE) { System.out.println( "Setting up model data to draw as arrays."); }
+		if (VERBOSE) { 
+		  System.out.println( "Setting up model data to draw as arrays."); 
+		}
 
 		// If we ONLY have vertex data, then transfer just that...
 		if ( ( hasVertices() ) && ( !hasFaces() ) && ( !hasNormals() ) )
 		{
-			if (VERBOSE) { System.out.println( "Model has no faces or normals. Transferring vertex data only."); }
+			if (VERBOSE) { 
+			  System.out.println( "Model has no faces or normals. Transferring vertex data only."); 
+			}
 
 			// Reset the vertex count
 			numVertices = 0;
@@ -695,12 +736,16 @@ public class Model
 			}
 
 			// Print a summary of the vertex data
-			if (VERBOSE) { System.out.println( "Number of vertices in data array: " + numVertices + " (" + getVertexDataSizeBytes() + " bytes)"); }
+			if (VERBOSE) { 
+			  System.out.println( "Number of vertices in data array: " + numVertices + " (" + getVertexDataSizeBytes() + " bytes)"); 
+			}
 		}
 		// If we have vertices AND faces BUT NOT normals...
 		else if ( ( hasVertices() ) && ( hasFaces() ) && ( !hasNormals() ) )
 		{
-			if (VERBOSE) { System.out.println("Model has vertices and faces, but no normals. Per-face normals will be generated.") ; }
+			if (VERBOSE) { 
+			  System.out.println("Model has vertices and faces, but no normals. Per-face normals will be generated.") ; 
+			}
 
 			// Create the vertexData and normalData arrays from the vector of faces
 			// Note: We generate the face normals ourselves.

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point2D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point2D.java
@@ -47,7 +47,7 @@ public class Point2D
 	private FloatBuffer pointSizeFloatBuffer;
 
 	//Define our vertex shader source code
-	private static final String vertexShaderSource =
+	private static final String VERTEX_SHADER_SOURCE =
 			"#version 330"                                                                                     		+ newLine +
 			"in vec2 vertexLocation;                                      // Incoming vertex attribute"             + newLine +
 			"in vec4 vertexColour;                                        // Incoming colour value"                 + newLine +
@@ -59,7 +59,7 @@ public class Point2D
 			"}";
 
 	//Define our fragment shader source code
-	private static final String fragmentShaderSource =
+	private static final String FRAGMENT_SHADER_SOURCE =
 			"#version 330"                                                   + newLine +
 			"flat in vec4 fragColour; // Incoming colour from vertex shader" + newLine +
 			"out vec4 vOutputColour;  // Outgoing colour value"              + newLine +
@@ -99,7 +99,7 @@ public class Point2D
 			pointShaderProgram = new ShaderProgram();
 
 			// Load, compile and link the shaders into the shader program
-			pointShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
+			pointShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point2D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point2D.java
@@ -35,19 +35,19 @@ public class Point2D
 	private static final int COMPONENT_COUNT = VERTEX_COMPONENTS + COLOUR_COMPONENTS;	
 
 	// Flag used so that we only initialise the shader once
-	private static boolean shaderInitialised = false;
+	private boolean shaderInitialised = false;
 
 	// Provide a definition of our static pointer to a ShaderProgram
-	private static ShaderProgram pointShaderProgram;
+	private ShaderProgram pointShaderProgram;
 
 	// Keep a FloatBuffer around to hold the ModelViewProjection matrix
-	private static FloatBuffer mvpMatrixFloatBuffer;
+	private FloatBuffer mvpMatrixFloatBuffer;
 
 	// We get the current OpenGL GL_POINT_SIZE before we use our own and then restore it drawing
-	private static FloatBuffer pointSizeFloatBuffer;
+	private FloatBuffer pointSizeFloatBuffer;
 
 	//Define our vertex shader source code
-	private static String vertexShaderSource =
+	private static final String vertexShaderSource =
 			"#version 330"                                                                                     		+ newLine +
 			"in vec2 vertexLocation;                                      // Incoming vertex attribute"             + newLine +
 			"in vec4 vertexColour;                                        // Incoming colour value"                 + newLine +
@@ -59,7 +59,7 @@ public class Point2D
 			"}";
 
 	//Define our fragment shader source code
-	private static String fragmentShaderSource =
+	private static final String fragmentShaderSource =
 			"#version 330"                                                   + newLine +
 			"flat in vec4 fragColour; // Incoming colour from vertex shader" + newLine +
 			"out vec4 vOutputColour;  // Outgoing colour value"              + newLine +
@@ -67,12 +67,10 @@ public class Point2D
 			"	vOutputColour = fragColour;"                                 + newLine +
 			"}";
 
-	// ----- Non-Static Properties -----
-
-	private static int         pointVaoId;          // The Vertex Array Object ID which holds our shader attributes
-	private static int         pointVertexBufferId; // The id of the vertex buffer containing the grid vertex data
-	private static float[]     pointData;          // Array of floats used to draw the grid
-	private static FloatBuffer vertexFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
+	private int         pointVaoId;          // The Vertex Array Object ID which holds our shader attributes
+	private int         pointVertexBufferId; // The id of the vertex buffer containing the grid vertex data
+	private float[]     pointData;          // Array of floats used to draw the grid
+	private FloatBuffer vertexFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
 
 	/** Constructor */
 	public Point2D()

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point2D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point2D.java
@@ -34,17 +34,14 @@ public class Point2D
 	// Total number of float components per vertex (2 + 4 = 6)
 	private static final int COMPONENT_COUNT = VERTEX_COMPONENTS + COLOUR_COMPONENTS;	
 
-	// Flag used so that we only initialise the shader once
-	private boolean shaderInitialised = false;
-
 	// Provide a definition of our static pointer to a ShaderProgram
-	private ShaderProgram pointShaderProgram;
+	private static ShaderProgram pointShaderProgram;
 
 	// Keep a FloatBuffer around to hold the ModelViewProjection matrix
-	private FloatBuffer mvpMatrixFloatBuffer;
+	private static FloatBuffer mvpMatrixFloatBuffer;
 
 	// We get the current OpenGL GL_POINT_SIZE before we use our own and then restore it drawing
-	private FloatBuffer pointSizeFloatBuffer;
+	private static FloatBuffer pointSizeFloatBuffer;
 
 	//Define our vertex shader source code
 	private static final String VERTEX_SHADER_SOURCE =
@@ -67,91 +64,88 @@ public class Point2D
 			"	vOutputColour = fragColour;"                                 + newLine +
 			"}";
 
-	private int         pointVaoId;          // The Vertex Array Object ID which holds our shader attributes
-	private int         pointVertexBufferId; // The id of the vertex buffer containing the grid vertex data
-	private float[]     pointData;          // Array of floats used to draw the grid
-	private FloatBuffer vertexFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
+	private static int         pointVaoId;          // The Vertex Array Object ID which holds our shader attributes
+	private static int         pointVertexBufferId; // The id of the vertex buffer containing the grid vertex data
+	private static float[]     pointData;          // Array of floats used to draw the grid
+	private static FloatBuffer vertexFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
+	
+	static {
+		// Instantiate our float data array which we'll transfer data from into the float buffer
+		pointData = new float[NUM_VERTICES * COMPONENT_COUNT];
+
+		// Create the float buffer which will hold the geometry data to draw
+		vertexFloatBuffer = Utils.createFloatBuffer(NUM_VERTICES * COMPONENT_COUNT);
+
+		// Create the float buffer which will hold the ModelViewProjection matrix
+		mvpMatrixFloatBuffer = Utils.createFloatBuffer(16);
+
+		// Create the FloatBuffer to hold the current OpenGL GL_POINT_SIZE so we can restore it later
+		// Note: LWJGL minimum size to get OpenGL data is 16, even though we only want to store 1 float.
+		pointSizeFloatBuffer = Utils.createFloatBuffer(16);			
+
+		// ----- Shader program setup -----
+
+		// Instantiate the shader program
+		pointShaderProgram = new ShaderProgram();
+
+		// Load, compile and link the shaders into the shader program
+		pointShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
+
+		// ----- Grid shader attributes and uniforms -----
+
+		// Add the shader attributes
+		pointShaderProgram.addAttribute("vertexLocation");
+		pointShaderProgram.addAttribute("vertexColour");
+
+		// Add the shader uniforms
+		pointShaderProgram.addUniform("mvpMatrix");
+
+		// ----- Set up our Vertex Array Object (VAO) to hold the shader attributes -----
+
+		// Get an Id for the Vertex Array Object (VAO) and bind to it
+		pointVaoId = glGenVertexArrays();
+		glBindVertexArray(pointVaoId);
+
+		// ----- Location Vertex Buffer Object (VBO) -----
+
+		// Generate an id for the locationBuffer and bind to it
+		pointVertexBufferId = glGenBuffers();
+		glBindBuffer(GL_ARRAY_BUFFER, pointVertexBufferId);
+
+		// Place the location data into the VBO...
+		glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
+
+		// ...and specify the data format.
+		glVertexAttribPointer(pointShaderProgram.attribute("vertexLocation"), // Vertex location attribute index
+                                                               VERTEX_COMPONENTS, // Number of vertex components per vertex
+                                                                        GL_FLOAT, // Data type
+                                                                           false, // Normalised?
+                                                   COMPONENT_COUNT * Float.BYTES, // Stride
+                                                                              0); // Offset
+
+		// ...and specify the data format.
+		glVertexAttribPointer(pointShaderProgram.attribute("vertexColour"),  // Vertex colour attribute index
+                                                           COLOUR_COMPONENTS,  // Number of colour components per vertex
+                                                                    GL_FLOAT,  // Data type
+                                                                       false,  // Normalised?
+                                               COMPONENT_COUNT * Float.BYTES,  // Stride
+                                       (long)VERTEX_COMPONENTS * Float.BYTES);  // Offset
+		// Unbind VBO
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+		// Enable the vertex attributes
+		glEnableVertexAttribArray( pointShaderProgram.attribute("vertexLocation") );
+		glEnableVertexAttribArray( pointShaderProgram.attribute("vertexColour")   );
+
+		// Unbind our Vertex Array object - all the buffer and attribute settings above will be associated with our VAO
+		glBindVertexArray(0);
+	}
 
 	/** Constructor */
 	public Point2D()
 	{
-		// If this is the first grid we're creating then do the shader setup
-		if (!shaderInitialised)
-		{
-			shaderInitialised = true;
-			
-			// Instantiate our float data array which we'll transfer data from into the float buffer
-			pointData = new float[NUM_VERTICES * COMPONENT_COUNT];
-
-			// Create the float buffer which will hold the geometry data to draw
-			vertexFloatBuffer = Utils.createFloatBuffer(NUM_VERTICES * COMPONENT_COUNT);
-
-			// Create the float buffer which will hold the ModelViewProjection matrix
-			mvpMatrixFloatBuffer = Utils.createFloatBuffer(16);
-
-			// Create the FloatBuffer to hold the current OpenGL GL_POINT_SIZE so we can restore it later
-			// Note: LWJGL minimum size to get OpenGL data is 16, even though we only want to store 1 float.
-			pointSizeFloatBuffer = Utils.createFloatBuffer(16);			
-
-			// ----- Shader program setup -----
-
-			// Instantiate the shader program
-			pointShaderProgram = new ShaderProgram();
-
-			// Load, compile and link the shaders into the shader program
-			pointShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
-
-			// ----- Grid shader attributes and uniforms -----
-
-			// Add the shader attributes
-			pointShaderProgram.addAttribute("vertexLocation");
-			pointShaderProgram.addAttribute("vertexColour");
-
-			// Add the shader uniforms
-			pointShaderProgram.addUniform("mvpMatrix");
-
-			// ----- Set up our Vertex Array Object (VAO) to hold the shader attributes -----
-
-			// Get an Id for the Vertex Array Object (VAO) and bind to it
-			pointVaoId = glGenVertexArrays();
-			glBindVertexArray(pointVaoId);
-
-				// ----- Location Vertex Buffer Object (VBO) -----
-	
-				// Generate an id for the locationBuffer and bind to it
-				pointVertexBufferId = glGenBuffers();
-				glBindBuffer(GL_ARRAY_BUFFER, pointVertexBufferId);
-	
-				// Place the location data into the VBO...
-				glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);
-	
-				// ...and specify the data format.
-				glVertexAttribPointer(pointShaderProgram.attribute("vertexLocation"), // Vertex location attribute index
-                                                                   VERTEX_COMPONENTS, // Number of vertex components per vertex
-                                                                            GL_FLOAT, // Data type
-                                                                               false, // Normalised?
-                                                       COMPONENT_COUNT * Float.BYTES, // Stride
-                                                                                  0); // Offset
-	
-				// ...and specify the data format.
-				glVertexAttribPointer(pointShaderProgram.attribute("vertexColour"),  // Vertex colour attribute index
-	                                                             COLOUR_COMPONENTS,  // Number of colour components per vertex
-	                                                                      GL_FLOAT,  // Data type
-	                                                                         false,  // Normalised?
-	                                                 COMPONENT_COUNT * Float.BYTES,  // Stride
-	                                         (long)VERTEX_COMPONENTS * Float.BYTES);  // Offset
-				// Unbind VBO
-				glBindBuffer(GL_ARRAY_BUFFER, 0);
-	
-				// Enable the vertex attributes
-				glEnableVertexAttribArray( pointShaderProgram.attribute("vertexLocation") );
-				glEnableVertexAttribArray( pointShaderProgram.attribute("vertexColour")   );
-
-			// Unbind our Vertex Array object - all the buffer and attribute settings above will be associated with our VAO
-			glBindVertexArray(0);
-		}
-		
-	} // End of constructor
+		//
+	} 
 
 	/**
 	 * Draw a Point2D as a GL_POINT.
@@ -164,15 +158,7 @@ public class Point2D
 	// to pass to the shader as a uniform.
 	public void draw(Vec2f location, Colour4f colour, float pointSize, Mat4f mvpMatrix)
 	{
-		// Point x/y location
-		pointData[0] = location.x;
-		pointData[1] = location.y;
-
-		// Point colour
-		pointData[2] = colour.r;
-		pointData[3] = colour.g;
-		pointData[4] = colour.b;
-		pointData[5] = colour.a;
+		setPointData(location, colour);
 
 		// Transfer the point data into the vertex float buffer and flip it ready for use
 		vertexFloatBuffer.put(pointData);
@@ -188,38 +174,50 @@ public class Point2D
 		// Bind to our vertex buffer object
 		glBindVertexArray(pointVaoId);
 	
-			// Bind to the vertex buffer object (VBO) and place the new data into it
-			glBindBuffer(GL_ARRAY_BUFFER, pointVertexBufferId);
-			glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);		
-		
-				// Provide the projection matrix uniform
-				glUniformMatrix4fv(pointShaderProgram.uniform("mvpMatrix"), false, mvpMatrixFloatBuffer);
-			
-				// Store the current GL_POINT_SIZE
-				// Note: We MUST allocate a minimum of 16 floats in our FloatBuffer in LWJGL, we CANNOT
-				// just get a FloatBuffer with 1 float!
-				// Also: Previously we could have used 'glPushAttrib(GL_POINT_BIT); /* do stuff */ glPopAttrib();'
-				// - but this was deprecated in OpenGL 3.2 as a means to remove some of the state tracking
-				// from OpenGL after the move to a programmable pipeline (i.e. shader based) architecture.
-				glGetFloatv(GL_POINT_SIZE, pointSizeFloatBuffer);
-			
-				// Set the GL_POINT_SIZE to be the size requested
-				glPointSize(pointSize);
-			
-				// 	Draw the axis points
-				glDrawArrays(GL_POINTS, 0, NUM_VERTICES);
-			
-				// Restore the point width to the previous value
-				glPointSize( pointSizeFloatBuffer.get(0) );
+		// Bind to the vertex buffer object (VBO) and place the new data into it
+		glBindBuffer(GL_ARRAY_BUFFER, pointVertexBufferId);
+		glBufferData(GL_ARRAY_BUFFER, vertexFloatBuffer, GL_DYNAMIC_DRAW);		
+	
+		// Provide the projection matrix uniform
+		glUniformMatrix4fv(pointShaderProgram.uniform("mvpMatrix"), false, mvpMatrixFloatBuffer);
+	
+		// Store the current GL_POINT_SIZE
+		// Note: We MUST allocate a minimum of 16 floats in our FloatBuffer in LWJGL, we CANNOT
+		// just get a FloatBuffer with 1 float!
+		// Also: Previously we could have used 'glPushAttrib(GL_POINT_BIT); /* do stuff */ glPopAttrib();'
+		// - but this was deprecated in OpenGL 3.2 as a means to remove some of the state tracking
+		// from OpenGL after the move to a programmable pipeline (i.e. shader based) architecture.
+		glGetFloatv(GL_POINT_SIZE, pointSizeFloatBuffer);
+	
+		// Set the GL_POINT_SIZE to be the size requested
+		glPointSize(pointSize);
+	
+		// 	Draw the axis points
+		glDrawArrays(GL_POINTS, 0, NUM_VERTICES);
+	
+		// Restore the point width to the previous value
+		glPointSize( pointSizeFloatBuffer.get(0) );
 
-			// Unbind from VBO
-			glBindBuffer(GL_ARRAY_BUFFER, 0);
+		// Unbind from VBO
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 		// Unbind from our VAO
 		glBindVertexArray(0);
 
 		// Disable our shader program
 		pointShaderProgram.disable();
+	}
+	
+	private static void setPointData(Vec2f location, Colour4f colour) {
+		// Point x/y location
+		pointData[0] = location.x;
+		pointData[1] = location.y;
+
+		// Point colour
+		pointData[2] = colour.r;
+		pointData[3] = colour.g;
+		pointData[4] = colour.b;
+		pointData[5] = colour.a;		
 	}
 	
 } // End of Point2D class

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point2D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point2D.java
@@ -103,10 +103,6 @@ public class Point2D
 			// Load, compile and link the shaders into the shader program
 			pointShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
 
-			// We no longer need the shader sources, so make them null so the GC can free them
-			vertexShaderSource   = null;
-			fragmentShaderSource = null;
-
 			// ----- Grid shader attributes and uniforms -----
 
 			// Add the shader attributes
@@ -145,7 +141,7 @@ public class Point2D
 	                                                                      GL_FLOAT,  // Data type
 	                                                                         false,  // Normalised?
 	                                                 COMPONENT_COUNT * Float.BYTES,  // Stride
-	                                              VERTEX_COMPONENTS * Float.BYTES);  // Offset
+	                                         (long)VERTEX_COMPONENTS * Float.BYTES);  // Offset
 				// Unbind VBO
 				glBindBuffer(GL_ARRAY_BUFFER, 0);
 	

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point3D.java
@@ -148,7 +148,7 @@ public class Point3D
 	                                                                      GL_FLOAT,  // Data type
 	                                                                         false,  // Normalised?
 	                                                 COMPONENT_COUNT * Float.BYTES,  // Stride
-	                                              VERTEX_COMPONENTS * Float.BYTES);  // Offset
+	                                         (long)VERTEX_COMPONENTS * Float.BYTES);  // Offset
 				// Unbind VBO
 				glBindBuffer(GL_ARRAY_BUFFER, 0);
 	

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point3D.java
@@ -35,19 +35,19 @@ public class Point3D
 	private static final int COMPONENT_COUNT = VERTEX_COMPONENTS + COLOUR_COMPONENTS;	
 
 	// Flag used so that we only initialise the shader once
-	private static boolean shaderInitialised = false;
+	private boolean shaderInitialised = false;
 
 	// Provide a definition of our static pointer to a ShaderProgram
-	private static ShaderProgram pointShaderProgram;
+	private ShaderProgram pointShaderProgram;
 
 	// Keep a FloatBuffer around to hold the ModelViewProjection matrix
-	private static FloatBuffer mvpMatrixFloatBuffer;
+	private FloatBuffer mvpMatrixFloatBuffer;
 
 	// We get the current OpenGL GL_POINT_SIZE before we use our own and then restore it drawing
-	private static FloatBuffer pointSizeFloatBuffer;
+	private FloatBuffer pointSizeFloatBuffer;
 
 	//Define our vertex shader source code
-	private static String vertexShaderSource =
+	private static final String vertexShaderSource =
 			"#version 330"                                                                                     + newLine +
 			"in vec3 vertexLocation;                                 // Incoming vertex attribute"             + newLine +
 			"in vec4 vertexColour;                                   // Incoming colour value"                 + newLine +
@@ -59,7 +59,7 @@ public class Point3D
 			"}";
 
 	//Define our fragment shader source code
-	private static String fragmentShaderSource =
+	private static final String fragmentShaderSource =
 			"#version 330"                                                   + newLine +
 			"flat in vec4 fragColour; // Incoming colour from vertex shader" + newLine +
 			"out vec4 vOutputColour;  // Outgoing colour value"              + newLine +
@@ -67,12 +67,10 @@ public class Point3D
 			"	vOutputColour = fragColour;"                                 + newLine +
 			"}";
 
-	// ----- Non-Static Properties -----
-
-	private static int         pointVaoId;          // The Vertex Array Object ID which holds our shader attributes
-	private static int         pointVertexBufferId; // The id of the vertex buffer containing the grid vertex data
-	private static float[]     pointData;          // Array of floats used to draw the grid
-	private static FloatBuffer vertexFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
+	private int         pointVaoId;          // The Vertex Array Object ID which holds our shader attributes
+	private int         pointVertexBufferId; // The id of the vertex buffer containing the grid vertex data
+	private float[]     pointData;          // Array of floats used to draw the grid
+	private FloatBuffer vertexFloatBuffer;  // Vertex buffer to hold the gridArray vertex data
 
 	// Constructor
 	// Note: width is along +/- x-axis, depth is along +/- z-axis, height is the location on
@@ -104,10 +102,6 @@ public class Point3D
 
 			// Load, compile and link the shaders into the shader program
 			pointShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
-
-			// We no longer need the shader sources, so make them null so the GC can free them
-			vertexShaderSource   = null;
-			fragmentShaderSource = null;
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point3D.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/Point3D.java
@@ -47,7 +47,7 @@ public class Point3D
 	private FloatBuffer pointSizeFloatBuffer;
 
 	//Define our vertex shader source code
-	private static final String vertexShaderSource =
+	private static final String VERTEX_SHADER_SOURCE =
 			"#version 330"                                                                                     + newLine +
 			"in vec3 vertexLocation;                                 // Incoming vertex attribute"             + newLine +
 			"in vec4 vertexColour;                                   // Incoming colour value"                 + newLine +
@@ -59,7 +59,7 @@ public class Point3D
 			"}";
 
 	//Define our fragment shader source code
-	private static final String fragmentShaderSource =
+	private static final String FRAGMENT_SHADER_SOURCE =
 			"#version 330"                                                   + newLine +
 			"flat in vec4 fragColour; // Incoming colour from vertex shader" + newLine +
 			"out vec4 vOutputColour;  // Outgoing colour value"              + newLine +
@@ -101,7 +101,7 @@ public class Point3D
 			pointShaderProgram = new ShaderProgram();
 
 			// Load, compile and link the shaders into the shader program
-			pointShaderProgram.initFromStrings(vertexShaderSource, fragmentShaderSource);
+			pointShaderProgram.initFromStrings(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
 
 			// ----- Grid shader attributes and uniforms -----
 

--- a/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/ShaderProgram.java
+++ b/caliko-visualisation/src/main/java/au/edu/federation/caliko/visualisation/ShaderProgram.java
@@ -49,8 +49,8 @@ public class ShaderProgram
 		glUseProgram(mProgramId);
 
 		// Instantiate our maps
-		mAttributeMap = new HashMap<String, Integer>();
-		mUniformMap   = new HashMap<String, Integer>();
+		mAttributeMap = new HashMap<>();
+		mUniformMap   = new HashMap<>();
 	}
 
 	/**
@@ -340,9 +340,6 @@ public class ShaderProgram
 
 		// Compile the shader
 		glCompileShader(shaderId);
-
-		// We no longer need to keep the shader source around, so mark it as null so the GC can free the memory
-		shaderSource = null;
 
 		// Get the shader compilation status
 		int shaderStatus = glGetShaderi(shaderId, GL_COMPILE_STATUS);

--- a/caliko/src/main/java/au/edu/federation/caliko/BaseboneConstraintType.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/BaseboneConstraintType.java
@@ -1,0 +1,8 @@
+package au.edu.federation.caliko;
+
+/**
+ * @author jsalvo
+ */
+public interface BaseboneConstraintType {
+
+}

--- a/caliko/src/main/java/au/edu/federation/caliko/BoneConnectionPoint.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/BoneConnectionPoint.java
@@ -1,0 +1,8 @@
+package au.edu.federation.caliko;
+
+/**
+ * Enum on how a FabrikBone may be connected together at either the start or end of the 'host' bone being connected to. 
+ * 
+ * @author jsalvo
+ */
+public enum BoneConnectionPoint { START, END }

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikBone.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikBone.java
@@ -6,8 +6,6 @@ import au.edu.federation.utils.Vectorf;
  * Interface for a bone
  * 
  * @author jsalvo
- *
- * @param <T>
  */
 @SuppressWarnings("rawtypes")
 public interface FabrikBone<V extends Vectorf, J extends FabrikJoint> {
@@ -52,7 +50,6 @@ public interface FabrikBone<V extends Vectorf, J extends FabrikJoint> {
 	 * and used throughout the lifetime of the bone.
 	 * 
 	 * @return	The length of this bone, as stored in the mLength property.
-	 * @see mLength
 	 */
 	float length();
 	
@@ -64,6 +61,7 @@ public interface FabrikBone<V extends Vectorf, J extends FabrikJoint> {
 	 * of the bone.
 	 * 
 	 * @return  The joint associated with this bone.
-	 */	J getJoint();
+	 */	
+	J getJoint();
 
 }

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikBone.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikBone.java
@@ -1,0 +1,69 @@
+package au.edu.federation.caliko;
+
+import au.edu.federation.utils.Vectorf;
+
+/**
+ * Interface for a bone
+ * 
+ * @author jsalvo
+ *
+ * @param <T>
+ */
+@SuppressWarnings("rawtypes")
+public interface FabrikBone<V extends Vectorf, J extends FabrikJoint> {
+	
+	/**
+	 * Return the start location of this bone.
+	 *
+	 * @return	The start location of this bone.
+	 */
+	V getStartLocation();
+	
+	/**
+	 * Return the end location of this bone.
+	 *
+	 * @return	The end location of this bone.
+	 */
+	V getEndLocation();
+	
+	/**
+	 * Set the start location of this bone from a provided vector.
+	 * <p>
+	 * No validation is performed on the value of the start location - be aware
+	 * that adding a bone with identical start and end locations will result in
+	 * undefined behaviour. 
+	 * @param	location	The bone start location specified as a vector.
+	 */
+	void setStartLocation(V location);
+	
+	/**
+	 * Set the end location of this bone from a provided vector.
+	 * <p>
+	 * No validation is performed on the value of the end location - be aware
+	 * that adding a bone with identical start and end locations will result in
+	 * undefined behaviour. 
+	 * @param	location	The bone end location specified as a vector.
+	 */
+	void setEndLocation(V location);
+	
+
+	/**
+	 * Return the length of this bone. This value is calculated when the bone is constructed
+	 * and used throughout the lifetime of the bone.
+	 * 
+	 * @return	The length of this bone, as stored in the mLength property.
+	 * @see mLength
+	 */
+	float length();
+	
+	/**
+	 * Get the joint associated with this bone.
+	 * <p>
+	 * Each bone has precisely one joint. Although the joint does not
+	 * have a location, it can conceptually be thought of to be located at the start location
+	 * of the bone.
+	 * 
+	 * @return  The joint associated with this bone.
+	 */	J getJoint();
+
+}

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikBone2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikBone2D.java
@@ -1,6 +1,7 @@
 package au.edu.federation.caliko;
 
 import au.edu.federation.utils.Colour4f;
+import au.edu.federation.utils.Mat4f;
 import au.edu.federation.utils.Utils;
 import au.edu.federation.utils.Vec2f;
 
@@ -14,7 +15,7 @@ import au.edu.federation.utils.Vec2f;
  * @author Al Lansley
  * @version 0.9.1 - 20/07/2016
  */
-public class FabrikBone2D
+public class FabrikBone2D implements FabrikBone<Vec2f,FabrikJoint2D>
 {
 	/**
 	 * mJoint	The joint attached to this FabrikBone2D.
@@ -263,14 +264,9 @@ public class FabrikBone2D
 	// ---------- Methods ----------
 
 	/**
-	 * Return the length of this bone.
-	 * <p>
-	 * Once the length of a bone has been set, either implicitly by a constructor that takes the start
-	 * and end locations of the bone and calculates the distance between them, or by explicitly specifying
-	 * the bone length, then it typically remains unchanged for the lifetime of the bone.
-	 * 
-	 * @return	The length of the bone in world-space, as stored in the mLength property.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public float length() {	return mLength; }
 
 	/**
@@ -297,10 +293,9 @@ public class FabrikBone2D
 	public float getLineWidth()	{ return mLineWidth; }
 	
 	/**
-	 * Get the start location of this bone as a Vec2f.
-	 * 
-	 * @return  The start location of this bone in world-space.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec2f getStartLocation() { return mStartLocation; }
 	
 	/**
@@ -311,10 +306,9 @@ public class FabrikBone2D
 	public float[] getStartLocationAsArray() { return new float[] { mStartLocation.x, mStartLocation.y }; }
 	
 	/**
-	 * Get the end location of this bone in world-space as a Vec2f.
-	 * 
-	 * @return  The end location of this bone.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec2f getEndLocation() { return mEndLocation; }
 	
 	/** Get the end location of the bone in world-space as an array of two floats.
@@ -331,14 +325,9 @@ public class FabrikBone2D
 	public void setJoint(FabrikJoint2D joint) {	mJoint.set(joint); }
 
 	/**
-	 * Get the FabrikJoint2D associated with this bone.
-	 * <p>
-	 * Each FabrikBone2D has precisely one {@link au.edu.federation.caliko.FabrikJoint2D}. Although the joint does not
-	 * have a location, it can conceptually be thought of to be located at the start location
-	 * of the bone.
-	 * 
-	 * @return  The FabrikJoint2D associated with this bone.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public FabrikJoint2D getJoint() { return mJoint; }
 
 	/**
@@ -433,27 +422,17 @@ public class FabrikBone2D
 		return sb.toString();
 	}
 	
-	// ---------- Package-Private Methods ----------
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void setStartLocation(Vec2f location) { mStartLocation.set(location); }
 	
 	/**
-	 * Set the start location of this bone from a provided Vec2f.
-	 * <p>
-	 * No validation is performed on the value of the start location - be aware
-	 * that adding a bone with identical start and end locations will result in
-	 * undefined behaviour. 
-	 * @param	location	The bone start location specified as a Vec2f.
+	 * {@inheritDoc}
 	 */
-	void setStartLocation(Vec2f location) { mStartLocation.set(location); }
-	
-	/**
-	 * Set the end location of this bone from a provided Vec2f.
-	 * <p>
-	 * No validation is performed on the value of the end location - be aware
-	 * that adding a bone with identical start and end locations will result in
-	 * undefined behaviour. 
-	 * @param	location	The bone end location specified as a Vec2f.
-	 */
-	void setEndLocation(Vec2f location) { mEndLocation.set(location); }
+	@Override
+	public void setEndLocation(Vec2f location) { mEndLocation.set(location); }
 	
 	/**
 	 * Set the length of the bone.

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikBone2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikBone2D.java
@@ -104,7 +104,7 @@ public class FabrikBone2D implements FabrikBone<Vec2f,FabrikJoint2D>
 	// ---------- Constructors ----------
 
 	/** Default constructor */
-	public FabrikBone2D() { }
+	FabrikBone2D() { }
 
 	/**
 	 * Constructor to create a new FabrikBone2D from a start and end location as provided by a pair of Vec2fs.
@@ -383,9 +383,13 @@ public class FabrikBone2D implements FabrikBone<Vec2f,FabrikJoint2D>
 	 */
 	public void setLineWidth(float lineWidth)
 	{
-		if (lineWidth < 1.0f ) { lineWidth = 1.0f;  }
-		if (lineWidth > 64.0f) { lineWidth = 64.0f; }
-		mLineWidth = lineWidth;
+		if (lineWidth < 1.0f ) { 
+		  mLineWidth = 1.0f;  
+		} else if (lineWidth > 64.0f) { 
+		  mLineWidth = 64.0f; 
+		} else {
+	    mLineWidth = lineWidth;
+		}
 	}
 	
 	/** 

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikBone3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikBone3D.java
@@ -28,7 +28,7 @@ public class FabrikBone3D implements FabrikBone<Vec3f,FabrikJoint3D>
 	private static final float MAX_LINE_WIDTH = 64.0f;
 	
 	/** Options for if a bone in another chain is connected to this bone, should it connect at the start or end location? */
-	public static enum BoneConnectionPoint3D { START, END };
+	public enum BoneConnectionPoint3D { START, END };
 	
 	/**
 	 * If this chain is connected to a bone in another chain, should this chain connect to the start or the end of that bone?

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikBone3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikBone3D.java
@@ -194,46 +194,15 @@ public class FabrikBone3D implements FabrikBone<Vec3f,FabrikJoint3D>
 	{
 		// Sanity checking
 		setLength(length); // Throws IAE if < zero
-		if ( !(directionUV.length() > 0.0f) ) { throw new IllegalArgumentException("Direction cannot be a zero vector"); }
+		if ( directionUV.length() <= 0.0f ) { 
+		  throw new IllegalArgumentException("Direction cannot be a zero vector"); 
+		}
 		
 		// Set the length, start and end locations
 		setLength(length);
 		mStartLocation.set(startLocation);
 		mEndLocation.set( mStartLocation.plus( directionUV.normalised().times(length) ) );
 	}
-	
-	/**
-	 * Create a new FabrikBone3D from a start location, a direction unit vector, a length and
-	 * a pair of constraint angles.
-	 * <p>
-	 * If the direction has a magnitude of zero, the length is not a positive value, or* if either
-	 * constraint angle is not within their valid ranges then an then an {@link IllegalArgumentException}
-	 * is thrown.
-	 * 
-	 * @see #setAnticlockwiseConstraintDegs(float)
-	 * @see #setClockwiseConstraintDegs(float)
-	 * @see #mColour
-	 * @see #mJoint
-	 * @see #mLineWidth
-	 * @see #mName
-	 */
-	/*public FabrikBone3D(Vec3f startLocation, Vec3f directionUV, float length, float clockwiseConstraintDegs, float anticlockwiseConstraintDegs)
-	{
-		// Set up as per previous constructor - IllegalArgumentExceptions will be thrown for invalid directions or lengths
-		this(startLocation, directionUV, length);
-		
-		// Set the constraint angles - IllegalArgumentExceptions will be thrown for invalid constraint angles
-		setClockwiseConstraintDegs(clockwiseConstraintDegs);
-		setAnticlockwiseConstraintDegs(anticlockwiseConstraintDegs);
-	}*/
-	
-	/*public FabrikBone3D(Vec3f startLocation, Vec3f directionUV, float length, float clockwiseConstraintDegs, float anticlockwiseConstraintDegs, Colour4f colour)
-	{
-		// Set up as per previous constructor - IllegalArgumentExceptions will be thrown for bad values
-		this(startLocation, directionUV, length, clockwiseConstraintDegs, anticlockwiseConstraintDegs);
-		
-		mColour.set(colour);
-	}*/
 	
 	/**
 	 * Create a named FabrikBone3D from a start location, a direction unit vector, a bone length and a name.
@@ -518,7 +487,6 @@ public class FabrikBone3D implements FabrikBone<Vec3f,FabrikJoint3D>
 	@Override
 	public String toString()
 	{
-		//Vec3f direction = this.getDirectionUV();
 		StringBuilder sb = new StringBuilder();
 		sb.append("Start joint location : " + mStartLocation  + NEW_LINE);
 		sb.append("End   joint location : " + mEndLocation    + NEW_LINE);

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikBone3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikBone3D.java
@@ -27,18 +27,15 @@ public class FabrikBone3D implements FabrikBone<Vec3f,FabrikJoint3D>
 	/** The maximum valid line width with which to draw a bone as a line is 64.0f pixels wide. */
 	private static final float MAX_LINE_WIDTH = 64.0f;
 	
-	/** Options for if a bone in another chain is connected to this bone, should it connect at the start or end location? */
-	public enum BoneConnectionPoint3D { START, END };
-	
 	/**
 	 * If this chain is connected to a bone in another chain, should this chain connect to the start or the end of that bone?
 	 * <p>
 	 * The default is to connect to the end of the specified bone.
 	 * <p>
 	 * This property can be set via the {#link #setBoneConnectionPoint(BoneConnectionPoint)} method, or when attaching this chain
-	 * to another chain via the {@link au.edu.federation.caliko.FabrikStructure3D#addConnectedChain(FabrikChain3D, int, int, BoneConnectionPoint)} method.
+	 * to another chain via the {@link au.edu.federation.caliko.FabrikStructure3D#connectChain(FabrikChain3D, int, int, BoneConnectionPoint)} method.
 	 */
-	private BoneConnectionPoint3D mBoneConnectionPoint = BoneConnectionPoint3D.END;
+	private BoneConnectionPoint mBoneConnectionPoint = BoneConnectionPoint.END;
 	
 	/**
 	 * mJoint	The joint attached to this FabrikBone3D.
@@ -321,10 +318,10 @@ public class FabrikBone3D implements FabrikBone<Vec3f,FabrikJoint3D>
 	 * <p>
 	 * The default is BoneConnectionPoint3D.END.
 	 * 
-	 * @param	bcp	The bone connection point to use (BoneConnectionPOint3D.START or BoneConnectionPoint3D.END).
+	 * @param	bcp	The bone connection point to use (BoneConnectionPoint3.START or BoneConnectionPoint.END).
 	 * 
 	 */
-	public void setBoneConnectionPoint(BoneConnectionPoint3D bcp) { mBoneConnectionPoint = bcp; }
+	public void setBoneConnectionPoint(BoneConnectionPoint bcp) { mBoneConnectionPoint = bcp; }
 	
 	/** 
 	 * Return the bone connection point for THIS bone, which will be either BoneConnectionPoint.START or BoneConnectionPoint.END.
@@ -334,7 +331,7 @@ public class FabrikBone3D implements FabrikBone<Vec3f,FabrikJoint3D>
 	 *
 	 * @return	The bone connection point for this bone.
 	 */
-	public BoneConnectionPoint3D getBoneConnectionPoint() { return mBoneConnectionPoint; }	
+	public BoneConnectionPoint getBoneConnectionPoint() { return mBoneConnectionPoint; }	
 
 	/**
 	 * Return the colour of this bone.

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikBone3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikBone3D.java
@@ -16,7 +16,7 @@ import au.edu.federation.utils.Vec3f;
  * @version 0.3.1 - 20/07/2016
  * @see FabrikJoint3D
  */
-public class FabrikBone3D
+public class FabrikBone3D implements FabrikBone<Vec3f,FabrikJoint3D>
 {
 	/** A line separator for the current system running this code. */
 	private static final String NEW_LINE = System.lineSeparator();
@@ -301,12 +301,9 @@ public class FabrikBone3D
 	// ---------- Methods ----------
 
 	/**
-	 * Return the length of this bone. This value is calculated when the bone is constructed
-	 * and used throughout the lifetime of the bone.
-	 * 
-	 * @return	The length of this bone, as stored in the mLength property.
-	 * @see mLength
+	 * {@inheritDoc}
 	 */
+	@Override
 	public float length() {	return mLength;	}
 	
 	/**
@@ -361,10 +358,9 @@ public class FabrikBone3D
 	public float getLineWidth()	{ return mLineWidth; }
 	
 	/**
-	 * Return the start location of this bone.
-	 *
-	 * @return	The start location of this bone.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec3f getStartLocation() { return mStartLocation; }
 	
 	/**
@@ -375,10 +371,9 @@ public class FabrikBone3D
 	public float[] getStartLocationAsArray() { return new float[] { mStartLocation.x, mStartLocation.y, mStartLocation.z }; }
 	
 	/**
-	 * Return the end location of this bone.
-	 *
-	 * @return	The end location of this bone.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec3f getEndLocation() { return mEndLocation; }
 	
 	/**
@@ -396,10 +391,9 @@ public class FabrikBone3D
 	public void setJoint(FabrikJoint3D joint) { mJoint.set(joint); }
 
 	/**
-	 * Return the FabrikJoint3D associated with this bone.
-	 *
-	 * @return	The FabrikJoint3D associated with this bone.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public FabrikJoint3D getJoint()	{ return mJoint; }
 	
 	/**
@@ -536,31 +530,20 @@ public class FabrikBone3D
 		return sb.toString();
 	}
 	
-	// ---------- Package-Private Methods ----------
-	
-	//TODO: This method being public is a problem - think about it and fix it.
 	/**
-	 * Set the start location of this bone from a provided Vec3f.
-	 * <p>
-	 * No validation is performed on the value of the start location - be aware
-	 * that adding a bone with identical start and end locations will result in
-	 * undefined behaviour. 
-	 * @param	location	The bone start location specified as a Vec3f.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public void setStartLocation(Vec3f location)
 	{
 		mStartLocation.set(location);
 	}
 	
 	/**
-	 * Set the end location of this bone from a provided Vec3f.
-	 * <p>
-	 * No validation is performed on the value of the end location - be aware
-	 * that adding a bone with identical start and end locations will result in
-	 * undefined behaviour. 
-	 * @param	location	The bone end location specified as a Vec3f.
+	 * {@inheritDoc}
 	 */
-	void setEndLocation(Vec3f location)
+	@Override
+	public void setEndLocation(Vec3f location)
 	{
 		mEndLocation.set(location);               
 	}

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain.java
@@ -1,0 +1,5 @@
+package au.edu.federation.caliko;
+
+public interface FabrikChain<B extends FabrikBone> {
+
+}

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain.java
@@ -10,15 +10,13 @@ public interface FabrikChain<B extends FabrikBone<V,J>, V extends Vectorf, J ext
 	/**
 	 * Add a bone to the end of this IK chain of this chain.
 	 * <p>
-	 * This chain's {@link mChainLength} property is updated to take into account the length of the
+	 * This chain's {@link #getChainLength()} property is updated to take into account the length of the
 	 * new bone added to the chain.
 	 * <p>
 	 * In addition, if the bone being added is the very first bone, then this chain's
-	 * {@link mFixedBaseLocation} property is set from the start joint location of the bone.
+	 * {@link #getBaseLocation()} property is set from the start joint location of the bone.
 	 * 
 	 * @param	bone	The FabrikBone to add to this FabrikChain.
-	 * @see		#mChainLength
-	 * @see		#mFixedBaseLocation
 	 */
 	void addBone(B bone);
 	
@@ -167,6 +165,8 @@ public interface FabrikChain<B extends FabrikBone<V,J>, V extends Vectorf, J ext
 	 * The FABRIK algorithm may require more than a single pass in order to solve
 	 * a given IK chain for an acceptable distance threshold. If we reach this
 	 * iteration limit then we stop attempting to solve the IK chain.
+	 * 
+	 * @return The maximum number of attempts that will be made to solve this IK chain.
 	 */
 	int getMaxIterationAttempts();
 	
@@ -175,11 +175,13 @@ public interface FabrikChain<B extends FabrikBone<V,J>, V extends Vectorf, J ext
 	 * <p>
 	 * If the current solve distance changes by less than this amount between solve attempt then we consider the
 	 * solve process to have stalled and dynamically abort any further attempts to solve the chain to minimise CPU usage.
+	 * 
+	 * @return The minimum iteration change before we dynamically abort any further attempts to solve this IK chain.
 	 */
 	float getMinIterationChange();
 	
 	/**
-	 * Return the distance threshold within which we consider the IK chain to be solved.
+	 * @return The distance threshold within which we consider the IK chain to be solved.
 	 */
 	float getSolveDistanceThreshold();		
 	

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain.java
@@ -1,5 +1,330 @@
 package au.edu.federation.caliko;
 
-public interface FabrikChain<B extends FabrikBone> {
+import java.util.List;
+
+import au.edu.federation.utils.Vectorf;
+
+@SuppressWarnings("rawtypes")
+public interface FabrikChain<B extends FabrikBone<V,J>, V extends Vectorf, J extends FabrikJoint, C extends BaseboneConstraintType> {
+	
+	/**
+	 * Add a bone to the end of this IK chain of this chain.
+	 * <p>
+	 * This chain's {@link mChainLength} property is updated to take into account the length of the
+	 * new bone added to the chain.
+	 * <p>
+	 * In addition, if the bone being added is the very first bone, then this chain's
+	 * {@link mFixedBaseLocation} property is set from the start joint location of the bone.
+	 * 
+	 * @param	bone	The FabrikBone to add to this FabrikChain.
+	 * @see		#mChainLength
+	 * @see		#mFixedBaseLocation
+	 */
+	void addBone(B bone);
+	
+	/**
+	 * Add a bone to the end of this IK chain given the direction unit vector and length of the new bone to add.
+	 * <p>
+	 * The bone added does not have any rotational constraints enforced, and will be drawn with a default colour
+	 * of white at full opacity.
+	 * <p>
+	 * This method can only be used when the IK chain contains a basebone, as without it we do not
+	 * have a start location for this bone (i.e. the end location of the previous bone).
+	 * <p>
+	 * If this method is executed on a chain which does not contain a basebone then a {@link RuntimeException}
+	 * is thrown.
+	 * <p>
+	 * If this method is provided with a direction unit vector of zero, or a bone length of zero then then an
+	 * {@link IllegalArgumentException} is thrown.
+	 * 
+	 * @param	directionUV The initial direction of the new bone
+	 * @param	length		The length of the new bone
+	 */
+	void addConsecutiveBone(V directionUV, float length);
+	
+	
+	/**
+	 * Return the basebone constraint type of this chain.
+	 * 
+	 * @return The basebone constraint type of this chain.
+	 */
+	C getBaseboneConstraintType();
+	
+	/**
+	 * Get the directional constraint of the basebone.
+	 * <p>
+	 * If the basebone is not constrained then a RuntimeException is thrown. If you wish to check whether the
+	 * basebone of this IK chain is constrained you may use the {@link #getBaseboneConstraintType()} method.
+	 * 
+	 * @return  The global directional constraint unit vector of the basebone of this IK chain.
+	 */	
+	V getBaseboneConstraintUV();
+	
+	/**
+	 * Return the basebone relative unit vector of this chain.
+	 * 
+	 * This direction is updated by the FabrikStructure when this chain is connected to another chain. There is
+	 * no other possible way of doing it as we have no knowledge of other chains, but the structure does, allowing
+	 * us to calculate this relative constraint UV.
+	 *  
+	 * @return The basebone relative constraint UV as updated (on solve) by the structure containing this chain.
+	 */ 
+	V getBaseboneRelativeConstraintUV();	
+	
+	/**
+	 * Return the base location of the IK chain.
+	 * <p>
+	 * Regardless of how many bones are contained in the chain, the base location is always the start location of the
+	 * first bone in the chain.
+	 * 
+	 * @return	The location of the start joint of the first bone in this chain.
+	 */
+	V getBaseLocation();
+	
+	/**
+	 * Return a bone by its zero-indexed location in the IK chain.
+	 * 
+	 * @param	boneNumber	The number of the bone to return from the Vector of FabrikBone3D objects.
+	 * @return				The specified bone.
+	 */
+	B getBone(int boneNumber);
+	
+	/**
+	 * Return the actual IK chain of this FabrikChain object,
+	 * 
+	 * @return		The IK chain of this FabrikChain as a List of FabrikBone objects.
+	 */
+	List<B> getChain();
+	
+	/**
+	 * Return the current length of this IK chain.
+	 * <p>
+	 * This method does not dynamically re-calculate the length of the chain - it merely returns the previously
+	 * calculated chain length, which gets updated each time a bone is added to the chain.
+	 * 
+	 * @return	The length of this IK chain.
+	 */
+	float getChainLength();
+	
+	/**
+	 * Return the index of the bone in another chain that this this chain is connected to.
+	 * <p>
+	 * Returns -1 (default) if this chain is not connected to another chain.
+	 * 
+	 * @return	The zero-indexed number of the bone we are connected to in the chain we are connected to.
+	 */ 
+	int getConnectedBoneNumber();
+
+	/**
+	 * Return the index of the chain in a FabrikStructure that this this chain is connected to.
+	 * <p>
+	 * Returns -1 (default) if this chain is not connected to another chain.
+	 * 
+	 * @return	The zero-index number of the chain we are connected to.
+	 */ 
+	int getConnectedChainNumber();
+	
+	
+	/**
+	 * Return the location of the end effector in the IK chain.
+	 * <p>
+	 * Regardless of how many bones are contained in the chain, the end effector is always the end location
+	 * of the final bone in the chain. 
+	 * 
+	 * @return	The location of this chain's end effector.
+	 */
+	V getEffectorLocation();
+	
+	/**
+	 * Return whether or not this chain uses an embedded target.
+	 * 
+	 * Embedded target mode may be enabled or disabled using setEmbeddededTargetMode(boolean).
+	 * 
+	 * @return whether or not this chain uses an embedded target.
+	 */
+	boolean getEmbeddedTargetMode();	
+	
+	/**
+	 * Return the embedded target location.
+	 * 
+	 * @return the embedded target location.
+	 */
+	V getEmbeddedTarget();
+	
+	/**
+	 * Return the target of the last solve attempt.
+	 * <p>
+	 * The target location and the effector location are not necessarily at the same location unless the chain has been solved
+	 * for distance, and even then they are still likely to be <i>similar</i> rather than <b>identical</b> values.
+	 * 
+	 * @return	The target location of the last solve attempt.
+	 */
+	V getLastTargetLocation();
+	
+	/**
+	 * Return the maximum number of attempts that will be made to solve this IK chain.
+	 * <p>
+	 * The FABRIK algorithm may require more than a single pass in order to solve
+	 * a given IK chain for an acceptable distance threshold. If we reach this
+	 * iteration limit then we stop attempting to solve the IK chain.
+	 */
+	int getMaxIterationAttempts();
+	
+	/**
+	 * Return the minimum iteration change before we dynamically abort any further attempts to solve this IK chain.
+	 * <p>
+	 * If the current solve distance changes by less than this amount between solve attempt then we consider the
+	 * solve process to have stalled and dynamically abort any further attempts to solve the chain to minimise CPU usage.
+	 */
+	float getMinIterationChange();
+	
+	/**
+	 * Return the distance threshold within which we consider the IK chain to be solved.
+	 */
+	float getSolveDistanceThreshold();		
+	
+	/**
+	 * Return the name of this FabrikChain.
+	 * 
+	 * @return	The name of his chain, or <strong>null</strong> if the name has not been set.
+	 */
+	String getName();
+	
+	/**
+	 * Return the number of bones in the IK chain.
+	 * <p>
+	 * Bones may be added to the chain via the addBone or addConsecutiveBone methods.
+	 * 
+	 * @return	The number of bones in the FabrikChain.
+	 */
+	int getNumBones();
+	
+	/**
+	 * Remove a bone from this IK chain by its zero-indexed location in the chain.
+	 * If the bone number to be removed does not exist in the chain then an IllegalArgumentException is thrown.
+	 * 
+	 * @param	boneNumber	The zero-indexed bone to remove from this IK chain.
+	 */
+	void removeBone(int boneNumber);
+	
+	/**
+	 * Set a directional constraint for the basebone.
+	 * <p>
+	 * @param	constraintUV	The direction unit vector to constrain the basebone to.
+	 */
+	void setBaseboneConstraintUV(V constraintUV);
+	
+	/**
+	 * Set the base location of this chain.
+	 *
+	 * @param	baseLocation	The location.
+	 */
+	void setBaseLocation(V baseLocation);	
+	
+	/**
+	 * Specify whether we should use the embedded target location when solving the IK chain.
+	 * 
+	 * @param	value	Whether we should use the embedded target location when solving the IK chain.
+	 */
+	void setEmbeddedTargetMode(boolean value);
+	
+	/**
+	 * Set the fixed basebone mode for this chain.
+	 * <p>
+	 * If the basebone is 'fixed' in place, then its start location cannot move. The bone is still allowed to
+	 * rotate, with or without constraints.
+	 * <p>
+	 * Specifying a non-fixed base location while this chain is connected to another chain will result in a
+	 * RuntimeException being thrown.
+	 * <p>
+	 * Fixing the basebone's start location in place and constraining to a global absolute direction are
+	 * mutually exclusive. Disabling fixed base mode while the chain's constraint type is
+	 * BaseboneConstraintType2/3D.GLOBAL_ABSOLUTE will result in a RuntimeException being thrown.	 * 
+	 *  
+	 * @param  value  Whether or not to fix the basebone start location in place.
+	 */
+	void setFixedBaseMode(boolean value);	
+	
+	/**
+	 * Set the maximum number of attempts that will be made to solve this IK chain.
+	 * <p>
+	 * The FABRIK algorithm may require more than a single pass in order to solve
+	 * a given IK chain for an acceptable distance threshold. If we reach this
+	 * iteration limit then we stop attempting to solve the IK chain.
+	 * <p>
+	 * Specifying a maxIterations value of less than 1 will result in an IllegalArgumentException is thrown.
+	 * 
+	 * @param maxIterations  The maximum number of attempts that will be made to solve this IK chain.
+	 */
+	void setMaxIterationAttempts(int maxIterations);
+	
+	/**
+	 * Set the minimum iteration change before we dynamically abort any further attempts to solve this IK chain.
+	 * <p>
+	 * If the current solve distance changes by less than this amount between solve attempt then we consider the
+	 * solve process to have stalled and dynamically abort any further attempts to solve the chain to minimise CPU usage.
+	 * <p>
+	 * If a minIterationChange value of less than zero is provided then an IllegalArgumentException is thrown.
+	 * 
+	 * @param minIterationChange  The minimum change in solve distance from one iteration to the next.
+	 */
+	void setMinIterationChange(float minIterationChange);
+	
+	/**
+	 * Set the distance threshold within which we consider the IK chain to be solved.
+	 * <p>
+	 * If a solve distance of less than zero is provided then an IllegalArgumentException is thrown.
+	 * 
+	 * @param  solveDistance  The distance between the end effector of this IK chain and target within which we will accept the solution.
+	 */
+	void setSolveDistanceThreshold(float solveDistance);	
+	
+	/** 
+	 * Set the name of this chain, capped to 100 characters if required.
+	 * 
+	 * @param	name	The name to set.
+	 */
+	void setName(String name);	
+	
+	/**
+	 * Solve this IK chain for the current embedded target location.
+	 * 
+	 * The embedded target location can be updated by calling updateEmbeddedTarget(V).
+	 * 
+	 * @return The distance between the end effector and the chain's embedded target location for our best solution.
+	 */
+	float solveForEmbeddedTarget();
+	
+	/**
+	 * Solve the IK chain for the target.
+	 * <p>
+	 * Iteratively attempt up to solve the chain up to a maximum of mMaxIterationAttempts.
+	 * 
+	 * This method may return early if any of the following conditions are met:
+	 * <ul>
+	 * <li>We've already solved for this target location,</li>
+	 * <li>We successfully solve for distance, or</li>
+	 * <li>We grind to a halt (i.e. low iteration change compared to previous solution).</li>
+	 * </ul>
+	 * 
+	 * @param newTarget	The target location to solve this IK chain for.
+	 * 
+	 * @return	The distance between the end effector and the target for our best solution
+	 * @see 	#getMaxIterationAttempts()
+	 * @see 	#getSolveDistanceThreshold()
+	 * @see 	#getMinIterationChange()
+	 */
+	float solveForTarget(V newTarget);
+	
+	/**
+	 * Update the embedded target for this chain.
+	 * 
+	 * The internal mEmbeddedTarget object is updated with the location of the provided parameter.
+	 * If the chain is not in useEmbeddedTarget mode then a RuntimeException is thrown.
+	 * Embedded target mode can be enabled by calling setEmbeddedTargetMode(true) on the chain.
+	 * 
+	 * @param newEmbeddedTarget	The location of the embedded target.
+	 */
+	void updateEmbeddedTarget(V newEmbeddedTarget);	
 
 }

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain2D.java
@@ -29,7 +29,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * 
 	 * @see #setBaseboneConstraintType(BaseboneConstraintType2D)
 	 */
-	public enum BaseboneConstraintType2D	implements BaseboneConstraintType { NONE,	GLOBAL_ABSOLUTE, LOCAL_RELATIVE, LOCAL_ABSOLUTE };
+	public enum BaseboneConstraintType2D	implements BaseboneConstraintType { NONE,	GLOBAL_ABSOLUTE, LOCAL_RELATIVE, LOCAL_ABSOLUTE }
 	
 	// ---------- Private Properties ----------
 
@@ -872,7 +872,9 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 				mChain.get(loop).setStartLocation(newStartLocation);
 
 				// ...and set the end joint location of the bone further in to also be at the new start location.
-				if (loop > 0) mChain.get(loop-1).setEndLocation(newStartLocation);
+				if (loop > 0) { 
+				  mChain.get(loop-1).setEndLocation(newStartLocation);
+				}
 			}
 
 		} // End of forward-pass loop over all bones
@@ -944,7 +946,9 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 					mChain.get(0).setEndLocation(newEndLocation);
 	
 					// Also, set the start location of the next bone to be the end location of this bone
-					if (mChain.size() > 1) mChain.get(1).setStartLocation(newEndLocation);
+					if (mChain.size() > 1) { 
+					  mChain.get(1).setStartLocation(newEndLocation);
+					}
 				}
 				else // ...otherwise we must constrain it to the base bone constraint unit vector
 				{	
@@ -1027,7 +1031,11 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 			sb.append("Number of bones: " + mNumBones + Utils.NEW_LINE);
 			
 			sb.append("Fixed base mode: ");
-			if (mFixedBaseMode) { sb.append("Yes." + Utils.NEW_LINE); } else { sb.append("No." + Utils.NEW_LINE); }
+			if (mFixedBaseMode) { 
+			  sb.append("Yes." + Utils.NEW_LINE); 
+			} else { 
+			  sb.append("No." + Utils.NEW_LINE); 
+			}
 			
 			sb.append("Base location: " + getBaseLocation() );
 		
@@ -1096,8 +1104,12 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	public void updateEmbeddedTarget(Vec2f newEmbeddedTarget)
 	{
 		// Using embedded target mode? Overwrite embedded target with provided location
-		if (mUseEmbeddedTarget) { mEmbeddedTarget.set(newEmbeddedTarget);                                                                                  }
-		else                    { throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); }
+		if (mUseEmbeddedTarget) { 
+		  mEmbeddedTarget.set(newEmbeddedTarget); 
+		}
+		else { 
+		  throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); 
+		}
 	}
 	
 	/**
@@ -1113,8 +1125,12 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	public void updateEmbeddedTarget(float x, float y)
 	{
 		// Using embedded target mode? Overwrite embedded target with provided location
-		if (mUseEmbeddedTarget) { mEmbeddedTarget.set( new Vec2f(x, y) );                                                                                  }
-		else                    { throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); }
+		if (mUseEmbeddedTarget) { 
+		  mEmbeddedTarget.set( new Vec2f(x, y) ); 
+		}
+		else { 
+		  throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); 
+		}
 	}
 	
 	/**
@@ -1127,8 +1143,12 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	@Override
 	public float solveForEmbeddedTarget()
 	{
-		if (mUseEmbeddedTarget) { return solveForTarget(mEmbeddedTarget);                                                                                     }
-		else                    { throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); }
+		if (mUseEmbeddedTarget) { 
+		  return solveForTarget(mEmbeddedTarget); 
+		}
+		else { 
+		  throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); 
+		}
 	}
 	
 	/**
@@ -1208,12 +1228,16 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 				bestSolution = this.cloneChainVector();
 				
 				// Did we solve for distance? Great! Break out of the loop.
-				if (solveDistance < mSolveDistanceThreshold) { break; }
+				if (solveDistance < mSolveDistanceThreshold) { 
+				  break; 
+				}
 			}
 			else // Did not solve to our satisfaction? Okay...
 			{
 				// Did we grind to a halt? If so then it's time to break out of the loop.
-				if (Math.abs(solveDistance - lastPassSolveDistance) < mMinIterationChange) { break; }
+				if (Math.abs(solveDistance - lastPassSolveDistance) < mMinIterationChange) { 
+				  break; 
+				}
 			}
 			
 			// Update the last pass solve distance

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain2D.java
@@ -31,9 +31,6 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 */
 	public enum BaseboneConstraintType2D	implements BaseboneConstraintType { NONE,	GLOBAL_ABSOLUTE, LOCAL_RELATIVE, LOCAL_ABSOLUTE };
 	
-	/** Bones may be connected together at either the start or end of the 'host' bone being connected to. */
-	public enum BoneConnectionPoint2D { START, END };
-			
 	// ---------- Private Properties ----------
 
 	/**
@@ -169,11 +166,11 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * If this chain is connected to a bone in another chain, then this property controls whether
 	 * it should connect to the start end location of the host bone.
 	 * 
-	 * @default BoneConnectionPoint2D.END
+	 * @default BoneConnectionPoint.END
 	 * @see {@link #setBoneConnectionPoint(BoneConnectionPoint)}
-	 * {see {@link FabrikStructure2D#addConnectedChain(FabrikChain2D, int, int, BoneConnectionPoint)}
+	 * {see {@link FabrikStructure2D#connectChain(FabrikChain2D, int, int, BoneConnectionPoint)}
 	 */
-	private BoneConnectionPoint2D mBoneConnectionPoint = BoneConnectionPoint2D.END;
+	private BoneConnectionPoint mBoneConnectionPoint = BoneConnectionPoint.END;
 	
 	/**
 	 * The direction around which we should constrain the base bone, as provided to the setBaseboneConstraintUV method.
@@ -471,7 +468,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 *
 	 * @return	The bone connection point of this chain.
 	 */
-	public BoneConnectionPoint2D getBoneConnectionPoint() { return mBoneConnectionPoint; }
+	public BoneConnectionPoint getBoneConnectionPoint() { return mBoneConnectionPoint; }
 	
 	/**
 	 * Return the actual IK chain of this FabrikChain2D object,
@@ -650,13 +647,13 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * Set the bone connection point of this chain.
 	 * <p>
 	 * When this chain is connected to another chain, it may either connect to the bone in the other chain at
-	 * the start (BoneConnectionPoint2D.START) or end (BoneConnectionPoint2D.END) of the bone.
+	 * the start (BoneConnectionPoint.START) or end (BoneConnectionPoint.END) of the bone.
 	 * <p>
 	 * This property is held per-chain rather than per-bone for efficiency.
 	 * 
-	 * @param	boneConnectionPoint	The BoneConnectionPoint2D to set on this chain.
+	 * @param	boneConnectionPoint	The BoneConnectionPoint to set on this chain.
 	 */
-	public void setBoneConnectionPoint(BoneConnectionPoint2D boneConnectionPoint) { mBoneConnectionPoint = boneConnectionPoint; }
+	public void setBoneConnectionPoint(BoneConnectionPoint boneConnectionPoint) { mBoneConnectionPoint = boneConnectionPoint; }
 
 	/**
 	 * Set the List%lt;FabrikBone2D%gt; of this FabrikChain2D to the provided list by reference.
@@ -712,6 +709,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 *  
 	 * @param  value  Whether or not to fix the base bone start location in place.
 	 */
+	@Override
 	public void setFixedBaseMode(boolean value)
 	{	
 		if (!value && mConnectedChainNumber != -1)
@@ -741,6 +739,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * 
 	 * @param maxIterations  The maximum number of attempts that will be made to solve this IK chain.
 	 */
+	@Override
 	public void setMaxIterationAttempts(int maxIterations)
 	{
 		// Ensure we have a valid maximum number of iteration attempts
@@ -763,6 +762,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * 
 	 * @param minIterationChange  The minimum change in solve distance from one iteration to the next.
 	 */
+	@Override
 	public void setMinIterationChange(float minIterationChange)
 	{
 		// Ensure we have a valid maximum number of iteration attempts
@@ -780,6 +780,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * 
 	 * @param	name	The name to set.
 	 */
+	 @Override
 	public void setName(String name) { mName = Utils.getValidatedName(name); }
 
 	/**
@@ -789,6 +790,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * 
 	 * @param  solveDistance  The distance between the end effector of this IK chain and target within which we will accept the solution.
 	 */
+	 @Override
 	public void setSolveDistanceThreshold(float solveDistance)
 	{
 		// Ensure we have a valid solve distance
@@ -1009,6 +1011,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * 
 	 * @param	value	Whether we should use the embedded target location when solving the IK chain.
 	 */
+	@Override
 	public void setEmbeddedTargetMode(boolean value) { mUseEmbeddedTarget = value; }
 	
 	/**
@@ -1121,6 +1124,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint
 	 * 
 	 * @return The distance between the end effector and the chain's embedded target location for our best solution.
 	 */
+	@Override
 	public float solveForEmbeddedTarget()
 	{
 		if (mUseEmbeddedTarget) { return solveForTarget(mEmbeddedTarget);                                                                                     }

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain2D.java
@@ -3,6 +3,7 @@ package au.edu.federation.caliko;
 import java.util.ArrayList;
 import java.util.List;
 
+import au.edu.federation.caliko.FabrikChain2D.BaseboneConstraintType2D;
 import au.edu.federation.utils.Colour4f;
 import au.edu.federation.utils.Utils;
 import au.edu.federation.utils.Vec2f;
@@ -13,7 +14,7 @@ import au.edu.federation.utils.Vec2f;
  * @author Al Lansley
  * @version 1.1 - 02/08/2016
  */
-public class FabrikChain2D implements FabrikChain<FabrikBone2D>
+public class FabrikChain2D implements FabrikChain<FabrikBone2D,Vec2f,FabrikJoint2D,BaseboneConstraintType2D>
 {	
 	/**
 	 * Basebone constraint types.
@@ -28,10 +29,10 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @see #setBaseboneConstraintType(BaseboneConstraintType2D)
 	 */
-	public static enum BaseboneConstraintType2D	{ NONE,	GLOBAL_ABSOLUTE, LOCAL_RELATIVE, LOCAL_ABSOLUTE };
+	public enum BaseboneConstraintType2D	implements BaseboneConstraintType { NONE,	GLOBAL_ABSOLUTE, LOCAL_RELATIVE, LOCAL_ABSOLUTE };
 	
 	/** Bones may be connected together at either the start or end of the 'host' bone being connected to. */
-	public static enum BoneConnectionPoint2D { START, END };
+	public enum BoneConnectionPoint2D { START, END };
 			
 	// ---------- Private Properties ----------
 
@@ -39,7 +40,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * The core of a FabrikChain2D is a list of FabrikBone2D objects, where each bone contains a start and end location, and a joint
 	 * that stores any rotational constraints.
 	 */
-	private List<FabrikBone2D> mChain = new ArrayList<FabrikBone2D>();
+	private List<FabrikBone2D> mChain = new ArrayList<>();
 
 	/** 
 	 * The name of this FabrikChain2D object.
@@ -307,6 +308,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * @see		#mChainLength
 	 * @see		#mBaseLocation
 	 */
+	@Override
 	public void addBone(FabrikBone2D bone)
 	{
 		// Add the new bone to the end of the chain
@@ -404,6 +406,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * @param	directionUV			The initial direction of the new bone
 	 * @param	length				The length of the new bone
 	 */
+	@Override
 	public void addConsecutiveBone(Vec2f directionUV, float length)
 	{
 		addConsecutiveConstrainedBone( directionUV, length, 180.0f, 180.0f, new Colour4f() );
@@ -414,6 +417,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return The basebone constraint type of this chain.
 	 */
+	@Override
 	public BaseboneConstraintType2D getBaseboneConstraintType() { return mBaseboneConstraintType; }
 	
 	/**
@@ -421,6 +425,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return  The basebone constraint unit vector of this FabrikChain2D.
 	 */
+	@Override
 	public Vec2f getBaseboneConstraintUV() { return mBaseboneConstraintUV; }
 	
 	/**
@@ -432,6 +437,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return	The base location of this FabrikChain2D.
 	 */
+	@Override
 	public Vec2f getBaseLocation() 
 	{
 		if (mNumBones > 0)
@@ -452,6 +458,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * @param	boneNumber	The number of the bone to return from the Vector of FabrikBone2D objects.
 	 * @return	The FabrikBone2D at the given location in this chain. 
 	 */
+	@Override
 	public FabrikBone2D getBone(int boneNumber)
 	{
 		return mChain.get(boneNumber);
@@ -471,6 +478,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return		The IK chain of this FabrikChain2D as a List of FabrikBone2D objects.
 	 */
+	@Override
 	public List<FabrikBone2D> getChain() { return mChain; }
 
 	/**
@@ -481,6 +489,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return	The length of this IK chain as stored in the mChainLength property.
 	 */
+	@Override
 	public float getChainLength() { return mChainLength; }
 	
 	/**
@@ -488,6 +497,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 *
 	 * @return The connected bone number as stored in the mConnectedBoneNumber property.
 	 */
+	@Override
 	public int getConnectedBoneNumber() { return mConnectedBoneNumber; }
 	
 	/**
@@ -495,6 +505,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 *
 	 * @return The connected chain number as stored in the mConnectedChainNumber property.
 	 */
+	@Override
 	public int getConnectedChainNumber() { return mConnectedChainNumber; }
 	
 	/**
@@ -507,6 +518,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 *  
 	 * @return	Vec2f
 	 */
+	@Override
 	public Vec2f getEffectorLocation()
 	{
 		if (mNumBones > 0)
@@ -526,6 +538,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return whether or not this chain uses an embedded target.
 	 */
+	@Override
 	public boolean getEmbeddedTargetMode() { return mUseEmbeddedTarget; }
 	
 	/**
@@ -533,6 +546,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return the embedded target location.
 	 */
+	@Override
 	public Vec2f getEmbeddedTarget() { return mEmbeddedTarget; }
 	
 	/**
@@ -542,6 +556,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return	The last target location that we attempted to solve this chain for.
 	 */
+	@Override
 	public Vec2f getLastTargetLocation() { return mLastTargetLocation; }
 	
 	/**
@@ -552,6 +567,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * @see #setName(String)
 	 * @see #getName()
 	 */
+	@Override
 	public String getName() { return mName; }
 	
 	/**
@@ -561,6 +577,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * 
 	 * @return	The number of bones in the FabrikChain2D.
 	 */
+	@Override
 	public int getNumBones() { return mNumBones; }
 	
 	/**
@@ -576,6 +593,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * @see		#mChainLength
 	 * @see		#mBaseLocation
 	 */
+	@Override
 	public void removeBone(int boneNumber)
 	{
 		// If the bone number is a bone which exists...
@@ -610,6 +628,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * @see au.edu.federation.caliko.FabrikJoint2D#setClockwiseConstraintDegs
 	 * @see au.edu.federation.caliko.FabrikJoint2D#setAnticlockwiseConstraintDegs
 	 */
+	@Override
 	public void setBaseboneConstraintUV(Vec2f constraintUV)
 	{
 		// Sanity checking
@@ -695,14 +714,14 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 */
 	public void setFixedBaseMode(boolean value)
 	{	
-		if (value == false && mConnectedChainNumber != -1)
+		if (!value && mConnectedChainNumber != -1)
 		{
 			throw new RuntimeException("This chain is connected to another chain so must remain in fixed base mode.");
 		}
 		
 		// We cannot have a freely moving base location AND constrain the base bone - so if we have both
 		// enabled then we disable the base bone angle constraint here.
-		if (mBaseboneConstraintType == BaseboneConstraintType2D.GLOBAL_ABSOLUTE && value == false)
+		if (mBaseboneConstraintType == BaseboneConstraintType2D.GLOBAL_ABSOLUTE && !value)
 		{
 			throw new RuntimeException("Cannot set a non-fixed base mode when the chain's constraint type is BaseBoneConstraintType2D.GLOBAL_ABSOLUTE.");
 		}
@@ -1027,7 +1046,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 		int numBones = mChain.size();
 		
 		// Create a new Vector of FabrikBone2D objects large enough to contain all the bones in this chain
-		List<FabrikBone2D> clonedChain = new ArrayList<FabrikBone2D>(numBones);
+		List<FabrikBone2D> clonedChain = new ArrayList<>(numBones);
 
 		// For each bone in the chain being cloned...		
 		for (int loop = 0; loop < numBones; ++loop)
@@ -1164,7 +1183,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 		
 		// Not the same target? Then we must solve the chain for the new target.
 		// We'll start by creating a list of bones to store our best solution
-		List<FabrikBone2D> bestSolution = new ArrayList<FabrikBone2D>(this.mNumBones);
+		List<FabrikBone2D> bestSolution = new ArrayList<>(this.mNumBones);
 		
 		// We'll keep track of our best solve distance, starting it at a huge value which will be beaten on first attempt			
 		float bestSolveDistance     = Float.MAX_VALUE;
@@ -1214,6 +1233,7 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 *
 	 * @return	The relative constraint UV about which this bone connects to a bone in another chain.
 	 */
+	@Override
 	public Vec2f getBaseboneRelativeConstraintUV() { return mBaseboneRelativeConstraintUV; }
 	
 	/**
@@ -1224,5 +1244,30 @@ public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 	 * @param	constraintUV	The basebone relative constraint unit vector to set.
 	 */
 	public void setBaseboneRelativeConstraintUV(Vec2f constraintUV) { mBaseboneRelativeConstraintUV.set(constraintUV); }
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int getMaxIterationAttempts() {
+		return this.mMaxIterationAttempts;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public float getMinIterationChange() {
+		return this.mMinIterationChange;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public float getSolveDistanceThreshold() {
+		return this.mSolveDistanceThreshold;
+	}
+	
 
 } // End of FabrikChain2D class

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain2D.java
@@ -13,7 +13,7 @@ import au.edu.federation.utils.Vec2f;
  * @author Al Lansley
  * @version 1.1 - 02/08/2016
  */
-public class FabrikChain2D
+public class FabrikChain2D implements FabrikChain<FabrikBone2D>
 {	
 	/**
 	 * Basebone constraint types.

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain3D.java
@@ -32,7 +32,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 		LOCAL_ROTOR,  // Rotor constraint in the coordinate space of (i.e. relative to) the direction of the connected bone
 		GLOBAL_HINGE, // World-space hinge constraint
 		LOCAL_HINGE   // Hinge constraint in the coordinate space of (i.e. relative to) the direction of the connected bone
-	};
+	}
 	
 	// ---------- Private Properties ----------
 	
@@ -475,7 +475,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 		Utils.validateLength(length);
 				
 		// Cannot add a consectuive bone of any kind if the there is no basebone
-		if (mNumBones == 0) { throw new RuntimeException("You must add a basebone before adding a consectutive bone."); }
+		if (mNumBones == 0) { 
+		  throw new RuntimeException("You must add a basebone before adding a consectutive bone."); 
+		}
 		
 		// Normalise the direction and hinge rotation axis 
 		directionUV.normalise();
@@ -562,7 +564,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 		// Validate the bone direction and length and that we have a basebone
 		Utils.validateDirectionUV(boneDirectionUV);
 		Utils.validateLength(boneLength);
-		if (mNumBones == 0) { throw new RuntimeException("Add a basebone before attempting to add consectuive bones."); }
+		if (mNumBones == 0) { 
+		  throw new RuntimeException("Add a basebone before attempting to add consectuive bones."); 
+		}
 				
 		// Create the bone starting at the end of the previous bone, set its direction, constraint angle and colour
 		// then add it to the chain. Note: The default joint type of a new FabrikBone3D is JointType.BALL.
@@ -635,7 +639,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	@Override
 	public Vec3f getBaseboneConstraintUV()
 	{
-		if ( !(mBaseboneConstraintType == BaseboneConstraintType3D.NONE) )
+		if ( mBaseboneConstraintType != BaseboneConstraintType3D.NONE )
 		{
 			return mBaseboneConstraintUV;
 		}
@@ -875,10 +879,18 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	public void setRotorBaseboneConstraint(BaseboneConstraintType3D rotorType, Vec3f constraintAxis, float angleDegs)
 	{
 		// Sanity checking
-		if (mNumBones == 0)	                     { throw new RuntimeException("Chain must contain a basebone before we can specify the basebone constraint type."); }		
-		if ( !(constraintAxis.length() > 0.0f) ) { throw new IllegalArgumentException("Constraint axis cannot be zero.");                                             }
-		if (angleDegs < 0.0f  )                  { angleDegs = 0.0f;                                                                                                  }
-		if (angleDegs > 180.0f)                  { angleDegs = 180.0f;                                                                                                }		
+		if (mNumBones == 0)	{ 
+		  throw new RuntimeException("Chain must contain a basebone before we can specify the basebone constraint type."); 
+		}		
+		if ( constraintAxis.length() <= 0.0f ) { 
+		  throw new IllegalArgumentException("Constraint axis cannot be zero."); 
+		}
+		if (angleDegs < 0.0f ) { 
+		  angleDegs = 0.0f; 
+		}
+		if (angleDegs > 180.0f) { 
+		  angleDegs = 180.0f;
+		}		
 		if ( !(rotorType == BaseboneConstraintType3D.GLOBAL_ROTOR || rotorType == BaseboneConstraintType3D.LOCAL_ROTOR) )
 		{
 			throw new IllegalArgumentException("The only valid rotor types for this method are GLOBAL_ROTOR and LOCAL_ROTOR.");
@@ -908,15 +920,19 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	public void setHingeBaseboneConstraint(BaseboneConstraintType3D hingeType, Vec3f hingeRotationAxis, float cwConstraintDegs, float acwConstraintDegs, Vec3f hingeReferenceAxis)
 	{
 		// Sanity checking
-		if (mNumBones == 0)	{ throw new RuntimeException("Chain must contain a basebone before we can specify the basebone constraint type."); }		
-		if ( !( hingeRotationAxis.length() > 0.0f) )  { throw new IllegalArgumentException("Hinge rotation axis cannot be zero.");		       }
-		if ( !( hingeReferenceAxis.length() > 0.0f) ) { throw new IllegalArgumentException("Hinge reference axis cannot be zero.");		       }
-		if ( !( Vec3f.perpendicular(hingeRotationAxis, hingeReferenceAxis) ) ) 
-		{
+		if (mNumBones == 0)	{ 
+		  throw new RuntimeException("Chain must contain a basebone before we can specify the basebone constraint type."); 
+		}		
+		if ( hingeRotationAxis.length() <= 0.0f )  { 
+		  throw new IllegalArgumentException("Hinge rotation axis cannot be zero.");
+		}
+		if ( hingeReferenceAxis.length() <= 0.0f ) { 
+		  throw new IllegalArgumentException("Hinge reference axis cannot be zero.");	
+		}
+		if ( !( Vec3f.perpendicular(hingeRotationAxis, hingeReferenceAxis) ) ) {
 			throw new IllegalArgumentException("The hinge reference axis must be in the plane of the hinge rotation axis, that is, they must be perpendicular.");
 		}
-		if ( !(hingeType == BaseboneConstraintType3D.GLOBAL_HINGE || hingeType == BaseboneConstraintType3D.LOCAL_HINGE) )
-		{	
+		if ( !(hingeType == BaseboneConstraintType3D.GLOBAL_HINGE || hingeType == BaseboneConstraintType3D.LOCAL_HINGE) ) {	
 			throw new IllegalArgumentException("The only valid hinge types for this method are GLOBAL_HINGE and LOCAL_HINGE.");
 		}
 		
@@ -1065,11 +1081,15 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	{
 		// Sanity check chain exists
 		int numChains = structure.getNumChains();
-		if (chainNumber > numChains) { throw new IllegalArgumentException("Structure does not contain a chain " + chainNumber + " - it has " + numChains + " chains."); }
+		if (chainNumber > numChains) { 
+		  throw new IllegalArgumentException("Structure does not contain a chain " + chainNumber + " - it has " + numChains + " chains."); 
+		}
 		
 		// Sanity check bone exists
 		int numBones = structure.getChain(chainNumber).getNumBones();
-		if (boneNumber > numBones) { throw new IllegalArgumentException("Chain does not contain a bone " + boneNumber + " - it has " + numBones + " bones."); }
+		if (boneNumber > numBones) { 
+		  throw new IllegalArgumentException("Chain does not contain a bone " + boneNumber + " - it has " + numBones + " bones."); 
+		}
 		
 		// All good? Set the connection details
 		mConnectedChainNumber = chainNumber;
@@ -1212,8 +1232,12 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	@Override
 	public float solveForEmbeddedTarget()
 	{
-		if (mUseEmbeddedTarget) { return solveForTarget(mEmbeddedTarget);                                                                                     }
-		else                    { throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); }
+		if (mUseEmbeddedTarget) { 
+		  return solveForTarget(mEmbeddedTarget); 
+		}
+		else { 
+		  throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); 
+		}
 	}
 	
 	/**
@@ -1333,8 +1357,12 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 			sb.append("Base location  : " + getBaseLocation() + NEW_LINE);
 			sb.append("Chain length   : " + getChainLength()  + NEW_LINE);
 			
-			if (mFixedBaseMode) { sb.append("Fixed base mode: Yes" + NEW_LINE);	}
-			else                { sb.append("Fixed base mode: No"  + NEW_LINE); }
+			if (mFixedBaseMode) { 
+			  sb.append("Fixed base mode: Yes" + NEW_LINE);	
+			}
+			else { 
+			  sb.append("Fixed base mode: No"  + NEW_LINE); 
+			}
 			
 			for (int loop = 0; loop < mNumBones; ++loop)
 			{
@@ -1362,7 +1390,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	private float solveIK(Vec3f target)
 	{	
 		// Sanity check that there are bones in the chain
-		if (mNumBones == 0) { throw new RuntimeException("It makes no sense to solve an IK chain with zero bones."); }
+		if (mNumBones == 0) { 
+		  throw new RuntimeException("It makes no sense to solve an IK chain with zero bones."); 
+		}
 		
 		// ---------- Forward pass from end effector to base -----------
 
@@ -1575,7 +1605,6 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 						 !( Utils.approximatelyEquals(acwConstraintDegs, FabrikJoint3D.MAX_CONSTRAINT_ANGLE_DEGS, 0.001f) ) )
 					{
 						// Calc. the reference axis in local space
-						//Vec3f relativeHingeReferenceAxis = mBaseboneRelativeReferenceConstraintUV;//m.times( thisBoneJoint.getHingeReferenceAxis() ).normalise();
 						Vec3f relativeHingeReferenceAxis = m.times( thisBoneJoint.getHingeReferenceAxis() ).normalise();
 						
 						// Get the signed angle (about the hinge rotation axis) between the hinge reference axis and the hinge-rotation aligned bone UV
@@ -1605,7 +1634,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 
 				// If we are not working on the end effector bone, then we set the start joint location of the next bone in
 				// the chain (i.e. the bone closer to the target) to be the new end joint location of this bone.
-				if (loop < mNumBones - 1) { mChain.get(loop+1).setStartLocation(newEndLocation); }
+				if (loop < mNumBones - 1) { 
+				  mChain.get(loop+1).setStartLocation(newEndLocation); 
+				}
 			}
 			else // If we ARE working on the basebone...
 			{	
@@ -1627,7 +1658,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 					Vec3f newEndLocation = thisBone.getStartLocation().plus( thisBone.getDirectionUV().times(thisBoneLength) );
 					thisBone.setEndLocation(newEndLocation);	
 					
-					if (mNumBones > 1) { mChain.get(1).setStartLocation(newEndLocation); }
+					if (mNumBones > 1) { 
+					  mChain.get(1).setStartLocation(newEndLocation); 
+					}
 				}
 				else // ...otherwise we must constrain it to the basebone constraint unit vector
 				{	
@@ -1649,7 +1682,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 						thisBone.setEndLocation( newEndLocation );
 						
 						// Also, set the start location of the next bone to be the end location of this bone
-						if (mNumBones > 1) { mChain.get(1).setStartLocation(newEndLocation); }
+						if (mNumBones > 1) { 
+						  mChain.get(1).setStartLocation(newEndLocation); 
+						}
 					}
 					else if (mBaseboneConstraintType == BaseboneConstraintType3D.LOCAL_ROTOR)
 					{
@@ -1675,7 +1710,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 						thisBone.setEndLocation( newEndLocation );
 						
 						// Also, set the start location of the next bone to be the end location of this bone
-						if (mNumBones > 1) { mChain.get(1).setStartLocation(newEndLocation); }
+						if (mNumBones > 1) { 
+						  mChain.get(1).setStartLocation(newEndLocation); 
+						}
 					}
 					else if (mBaseboneConstraintType == BaseboneConstraintType3D.GLOBAL_HINGE)
 					{
@@ -1712,7 +1749,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 						thisBone.setEndLocation( newEndLocation );
 						
 						// Also, set the start location of the next bone to be the end location of this bone
-						if (mNumBones > 1) { mChain.get(1).setStartLocation(newEndLocation); }
+						if (mNumBones > 1) { 
+						  mChain.get(1).setStartLocation(newEndLocation); 
+						}
 					}
 					else if (mBaseboneConstraintType == BaseboneConstraintType3D.LOCAL_HINGE)
 					{
@@ -1730,7 +1769,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 						{
 							// Grab the hinge reference axis and calculate the current signed angle between it and our bone direction (about the hinge
 							// rotation axis). Note: ACW rotation is positive, CW rotation is negative.
-							Vec3f hingeReferenceAxis = mBaseboneRelativeReferenceConstraintUV; //thisJoint.getHingeReferenceAxis();
+							Vec3f hingeReferenceAxis = mBaseboneRelativeReferenceConstraintUV; 
 							float signedAngleDegs    = Vec3f.getSignedAngleBetweenDegs(hingeReferenceAxis, thisBoneInnerToOuterUV, hingeRotationAxis);
 							
 							// Constrain as necessary
@@ -1749,7 +1788,9 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 						thisBone.setEndLocation( newEndLocation );
 						
 						// Also, set the start location of the next bone to be the end location of this bone
-						if (mNumBones > 1) { mChain.get(1).setStartLocation(newEndLocation); }
+						if (mNumBones > 1) { 
+						  mChain.get(1).setStartLocation(newEndLocation); 
+						}
 					}
 					
 				} // End of basebone constraint handling section
@@ -1810,8 +1851,12 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	public void updateEmbeddedTarget(Vec3f newEmbeddedTarget)
 	{
 		// Using embedded target mode? Overwrite embedded target with provided location
-		if (mUseEmbeddedTarget) { mEmbeddedTarget.set(newEmbeddedTarget);                                                                                  }
-		else                    { throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); }
+		if (mUseEmbeddedTarget) { 
+		  mEmbeddedTarget.set(newEmbeddedTarget); 
+		}
+		else { 
+		  throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); 
+		}
 	}
 	
 	/**
@@ -1828,8 +1873,12 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	public void updateEmbeddedTarget(float x, float y, float z)
 	{
 		// Using embedded target mode? Overwrite embedded target with provided location
-		if (mUseEmbeddedTarget) { mEmbeddedTarget.set( new Vec3f(x, y, z) );                                                                                  }
-		else                    { throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); }
+		if (mUseEmbeddedTarget) { 
+		  mEmbeddedTarget.set( new Vec3f(x, y, z) ); 
+		}
+		else { 
+		  throw new RuntimeException("This chain does not have embedded targets enabled - enable with setEmbeddedTargetMode(true)."); 
+		}
 	}
 	
 	/**

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain3D.java
@@ -7,7 +7,6 @@ import au.edu.federation.caliko.FabrikJoint3D.JointType;
 import au.edu.federation.utils.Colour4f;
 import au.edu.federation.utils.Mat3f;
 import au.edu.federation.utils.Utils;
-import au.edu.federation.utils.Vec2f;
 import au.edu.federation.utils.Vec3f;
 
 /** Class to represent a 3D Inverse Kinematics (IK) chain that can be solved for a given target using the FABRIK algorithm.
@@ -18,7 +17,7 @@ import au.edu.federation.utils.Vec3f;
  * @author Al Lansley
  * @version 0.5 - 03/08/2016
  */
-public class FabrikChain3D
+public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 {	
 	private static final String NEW_LINE = System.lineSeparator();
 	

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain3D.java
@@ -3,6 +3,7 @@ package au.edu.federation.caliko;
 import java.util.ArrayList;
 import java.util.List;
 
+import au.edu.federation.caliko.FabrikChain3D.BaseboneConstraintType3D;
 import au.edu.federation.caliko.FabrikJoint3D.JointType;
 import au.edu.federation.utils.Colour4f;
 import au.edu.federation.utils.Mat3f;
@@ -17,14 +18,14 @@ import au.edu.federation.utils.Vec3f;
  * @author Al Lansley
  * @version 0.5 - 03/08/2016
  */
-public class FabrikChain3D implements FabrikChain<FabrikBone3D>
+public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint3D,BaseboneConstraintType3D>
 {	
 	private static final String NEW_LINE = System.lineSeparator();
 	
 	/**
 	 * Various types of basebone constraint types.
 	 */
-	public static enum BaseboneConstraintType3D
+	public enum BaseboneConstraintType3D implements BaseboneConstraintType
 	{
 		NONE,         // No constraint - basebone may rotate freely
 		GLOBAL_ROTOR, // World-space rotor constraint
@@ -39,7 +40,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * The core of a FabrikChain3D is a list of FabrikBone3D objects. It is this chain that we attempt to solve for a specified
 	 * target location via the {@link solveForTarget} method.
 	 */
-	private List<FabrikBone3D> mChain = new ArrayList<FabrikBone3D>();
+	private List<FabrikBone3D> mChain = new ArrayList<>();
 
 	/** 
 	 * The name of this FabrikChain3D object.
@@ -302,6 +303,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * @see		#mChainLength
 	 * @see		#mFixedBaseLocation
 	 */
+	@Override
 	public void addBone(FabrikBone3D bone)
 	{
 		// Add the new bone to the end of the ArrayList of bones
@@ -340,6 +342,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * @param	directionUV The initial direction of the new bone
 	 * @param	length		The length of the new bone
 	 */
+	@Override
 	public void addConsecutiveBone(Vec3f directionUV, float length) { addConsecutiveBone(directionUV, length, new Colour4f() ); }
 	
 	/**
@@ -595,7 +598,8 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * us to calculate this relative constraint UV.
 	 *  
 	 * @return The basebone relative constraint UV as updated (on solve) by the structure containing this chain.
-	 */ 
+	 */
+	@Override
 	public Vec3f getBaseboneRelativeConstraintUV() { return mBaseboneRelativeConstraintUV; }
 	
 	/**
@@ -603,6 +607,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 *
 	 * @return	The basebone constraint type of this chain.
 	 */
+	@Override
 	public BaseboneConstraintType3D getBaseboneConstraintType() { return mBaseboneConstraintType; }
 	
 	/**
@@ -627,6 +632,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return  The global directional constraint unit vector of the basebone of this IK chain.
 	 */
+	@Override
 	public Vec3f getBaseboneConstraintUV()
 	{
 		if ( !(mBaseboneConstraintType == BaseboneConstraintType3D.NONE) )
@@ -650,6 +656,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return	The location of the start joint of the first bone in this chain.
 	 */
+	@Override
 	public Vec3f getBaseLocation() { return mChain.get(0).getStartLocation(); }	
 	
 	/**
@@ -658,13 +665,15 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * @param	boneNumber	The number of the bone to return from the Vector of FabrikBone3D objects.
 	 * @return				The specified bone.
 	 */
+	@Override
 	public FabrikBone3D getBone(int boneNumber) { return mChain.get(boneNumber); }
 
 	/**
 	 * Return the List%lt;FabrikBone3D%gt; which comprises the actual IK chain of this FabrikChain3D object.
 	 *  
 	 * @return	The List%lt;FabrikBone3D%gt; which comprises the actual IK chain of this FabrikChain3D object.
-	 */	
+	 */
+	@Override
 	public List<FabrikBone3D> getChain() { return mChain; }
 	
 	/**
@@ -678,6 +687,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return	The pre-calculated length of the IK chain as stored in the mChainLength property.
 	 */
+	@Override
 	public float getChainLength() { return mChainLength; }
 	
 	/**
@@ -687,6 +697,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return	The zero-indexed number of the bone we are connected to in the chain we are connected to.
 	 */ 
+	@Override
 	public int getConnectedBoneNumber() { return mConnectedBoneNumber; }
 
 	/**
@@ -696,6 +707,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return	The zero-index number of the chain we are connected to.
 	 */ 
+	@Override
 	public int getConnectedChainNumber() { return mConnectedChainNumber; }
 	
 	/**
@@ -706,6 +718,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return	The location of this chain's end effector.
 	 */
+	@Override
 	public Vec3f getEffectorLocation() { return mChain.get(mNumBones-1).getEndLocation(); }
 
 	/**
@@ -715,6 +728,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return whether or not this chain uses an embedded target.
 	 */
+	@Override
 	public boolean getEmbeddedTargetMode() { return mUseEmbeddedTarget; }
 	
 	/**
@@ -722,6 +736,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return the embedded target location.
 	 */
+	@Override
 	public Vec3f getEmbeddedTarget() { return mEmbeddedTarget; }
 	
 	/**
@@ -732,6 +747,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return	The target location of the last solve attempt.
 	 */
+	@Override
 	public Vec3f getLastTargetLocation() { return mLastTargetLocation; }
 	
 	/**
@@ -760,6 +776,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 *
 	 * @return	The name of this IK chain.
 	 */
+	@Override
 	public String getName() { return mName; }
 	
 	/**
@@ -767,6 +784,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 *
 	 * @return	The number of bones in this IK chain.
 	 */
+	@Override
 	public int getNumBones() { return mNumBones; }
 	
 	/**
@@ -778,6 +796,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @param	boneNumber	The zero-indexed bone to remove from this IK chain.
 	 */
+	@Override
 	public void removeBone(int boneNumber)
 	{
 		// If the bone number is a bone which exists...
@@ -832,6 +851,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @param	value	Whether we should use the embedded target location when solving the IK chain.
 	 */
+	@Override
 	public void setEmbeddedTargetMode(boolean value) { mUseEmbeddedTarget = value; }
 	
 	/**
@@ -1000,6 +1020,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * @see		au.edu.federation.caliko.FabrikJoint3D#setHingeJointClockwiseConstraintDegs(float)
 	 * @see		au.edu.federation.caliko.FabrikJoint3D#setHingeJointAnticlockwiseConstraintDegs(float)
 	 */
+	@Override
 	public void setBaseboneConstraintUV(Vec3f constraintUV)
 	{
 		if (mBaseboneConstraintType == BaseboneConstraintType3D.NONE)
@@ -1026,6 +1047,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 *
 	 * @param	baseLocation	The fixed base location for this chain.
 	 */
+	@Override
 	public void setBaseLocation(Vec3f baseLocation) { mFixedBaseLocation = baseLocation; }
 
 	/**
@@ -1077,16 +1099,17 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 *  
 	 * @param  value  Whether or not to fix the basebone start location in place.
 	 */
+	@Override
 	public void setFixedBaseMode(boolean value)
 	{	
 		// Enforce that a chain connected to another chain stays in fixed base mode (i.e. it moves with the chain it's connected to instead of independently)
-		if (value == false && mConnectedChainNumber != -1)
+		if (!value && mConnectedChainNumber != -1)
 		{
 			throw new RuntimeException("This chain is connected to another chain so must remain in fixed base mode.");
 		}
 		
 		// We cannot have a freely moving base location AND constrain the basebone to an absolute direction
-		if (mBaseboneConstraintType == BaseboneConstraintType3D.GLOBAL_ROTOR && value == false)
+		if (mBaseboneConstraintType == BaseboneConstraintType3D.GLOBAL_ROTOR && !value)
 		{
 			throw new RuntimeException("Cannot set a non-fixed base mode when the chain's constraint type is BaseboneConstraintType3D.GLOBAL_ABSOLUTE_ROTOR.");
 		}
@@ -1108,6 +1131,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @param maxIterations  The maximum number of attempts that will be made to solve this IK chain.
 	 */
+	@Override
 	public void setMaxIterationAttempts(int maxIterations)
 	{
 		// Ensure we have a valid maximum number of iteration attempts
@@ -1132,6 +1156,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @param	minIterationChange  The minimum change in solve distance from one iteration to the next.
 	 */
+	@Override
 	public void setMinIterationChange(float minIterationChange)
 	{
 		// Ensure we have a valid maximum number of iteration attempts
@@ -1149,6 +1174,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @param	name	The name to set.
 	 */
+	@Override
 	public void setName(String name) { mName = Utils.getValidatedName(name); }
 	
 	/**
@@ -1158,6 +1184,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @param  solveDistance  The distance between the end effector of this IK chain and target within which we will accept the solution.
 	 */
+	@Override
 	public void setSolveDistanceThreshold(float solveDistance)
 	{
 		// Ensure we have a valid solve distance
@@ -1190,6 +1217,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @return The distance between the end effector and the chain's embedded target location for our best solution.
 	 */
+	@Override
 	public float solveForEmbeddedTarget()
 	{
 		if (mUseEmbeddedTarget) { return solveForTarget(mEmbeddedTarget);                                                                                     }
@@ -1229,6 +1257,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * @param	newTarget	The location of the target for which we will solve this IK chain.
 	 * @return	float		The resulting distance between the end effector and the new target location after solving the IK chain.
 	 */
+	@Override
 	public float solveForTarget(Vec3f newTarget)
 	{	
 		// If we have both the same target and base location as the last run then do not solve
@@ -1245,7 +1274,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 		 */
 						
 		// Declare a list of bones to use to store our best solution
-		List<FabrikBone3D> bestSolution = new ArrayList<FabrikBone3D>();
+		List<FabrikBone3D> bestSolution = new ArrayList<>();
 		
 		// We start with a best solve distance that can be easily beaten
 		float bestSolveDistance = Float.MAX_VALUE;
@@ -1785,6 +1814,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 	 * 
 	 * @param newEmbeddedTarget	The location of the embedded target.
 	 */
+	@Override
 	public void updateEmbeddedTarget(Vec3f newEmbeddedTarget)
 	{
 		// Using embedded target mode? Overwrite embedded target with provided location
@@ -1821,7 +1851,7 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 		int numBones = mChain.size();
 		
 		// Create a new Vector of FabrikBone3D objects of that size
-		List<FabrikBone3D> clonedChain = new ArrayList<FabrikBone3D>(numBones);
+		List<FabrikBone3D> clonedChain = new ArrayList<>(numBones);
 
 		// For each bone in the chain being cloned...		
 		for (int loop = 0; loop < numBones; ++loop)
@@ -1833,5 +1863,29 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D>
 		
 		return clonedChain;
 	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int getMaxIterationAttempts() {
+		return this.mMaxIterationAttempts;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public float getMinIterationChange() {
+		return this.mMinIterationChange;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public float getSolveDistanceThreshold() {
+		return this.mSolveDistanceThreshold;
+	}	
 
 } // End of FabrikChain3D class

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikChain3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikChain3D.java
@@ -1051,14 +1051,6 @@ public class FabrikChain3D implements FabrikChain<FabrikBone3D,Vec3f,FabrikJoint
 	public void setBaseLocation(Vec3f baseLocation) { mFixedBaseLocation = baseLocation; }
 
 	/**
-	 * Set the list of FabrikBone3D of this FabrikChain3D to the provided list by reference.
-	 * 
-	 * @param	chain	The list of FabrikBone3D objects to assign to the {@link #mChain} property.
-	 * @see		#mChain
-	 */
-	private void setChain(List<FabrikBone3D> chain) { this.mChain = chain; }
-
-	/**
 	 * Connect this chain to the specified bone in the specified chain in the provided structure.
 	 * <p>
 	 * In order to connect this chain to another chain, both chains must exist within the same structure.

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint.java
@@ -1,0 +1,11 @@
+package au.edu.federation.caliko;
+
+public interface FabrikJoint<T> {
+	
+	/**
+	 * Set the constraint angles of this joint to match those of a source joint, essentially making a copy of the source joint.
+	 * @param	sourceJoint	The source joint from which to copy values.
+	 */
+	void set(T sourceJoint);	
+
+}

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint2D.java
@@ -33,7 +33,7 @@ package au.edu.federation.caliko;
  * @author Al Lansley
  * @version 0.8 - 16/12/2015
  */
-public class FabrikJoint2D
+public class FabrikJoint2D implements FabrikJoint<FabrikJoint2D>
 {
 	/** The minimum valid constraint angle for both clockwise and anticlockwise rotation is 0 degrees. */
 	public static final float MIN_2D_CONSTRAINT_ANGLE_DEGS = 0.0f;

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint2D.java
@@ -100,6 +100,7 @@ public class FabrikJoint2D implements FabrikJoint<FabrikJoint2D>
 	 * Set the constraint angles of this FabrikJoint2D to match those of a source FabrikJoint2D, essentially making a copy of the source joint.
 	 * @param	sourceJoint	The source joint from which to copy values.
 	 */
+	@Override
 	public void set(FabrikJoint2D sourceJoint)
 	{	
 		setClockwiseConstraintDegs(sourceJoint.mClockwiseConstraintDegs);
@@ -115,9 +116,13 @@ public class FabrikJoint2D implements FabrikJoint<FabrikJoint2D>
 	 */
 	public void setClockwiseConstraintDegs(float angleDegs)
 	{		
-		if (angleDegs < MIN_2D_CONSTRAINT_ANGLE_DEGS) { angleDegs = MIN_2D_CONSTRAINT_ANGLE_DEGS; }
-		if (angleDegs > MAX_2D_CONSTRAINT_ANGLE_DEGS) { angleDegs = MAX_2D_CONSTRAINT_ANGLE_DEGS; }
-		mClockwiseConstraintDegs = angleDegs;
+		if (angleDegs < MIN_2D_CONSTRAINT_ANGLE_DEGS) { 
+		  mClockwiseConstraintDegs = MIN_2D_CONSTRAINT_ANGLE_DEGS; 
+		} else if (angleDegs > MAX_2D_CONSTRAINT_ANGLE_DEGS) { 
+		  mClockwiseConstraintDegs = MAX_2D_CONSTRAINT_ANGLE_DEGS; 
+		} else {
+	    mClockwiseConstraintDegs = angleDegs;
+		}
 	}
  
 	/**
@@ -130,9 +135,14 @@ public class FabrikJoint2D implements FabrikJoint<FabrikJoint2D>
 	 */
 	public void setAnticlockwiseConstraintDegs(float angleDegs)
 	{		
-		if (angleDegs < MIN_2D_CONSTRAINT_ANGLE_DEGS) { angleDegs = MIN_2D_CONSTRAINT_ANGLE_DEGS; }
-		if (angleDegs > MAX_2D_CONSTRAINT_ANGLE_DEGS) { angleDegs = MAX_2D_CONSTRAINT_ANGLE_DEGS; }
-		mAnticlockwiseConstraintDegs = angleDegs;
+		if (angleDegs < MIN_2D_CONSTRAINT_ANGLE_DEGS) { 
+		  mAnticlockwiseConstraintDegs = MIN_2D_CONSTRAINT_ANGLE_DEGS; 
+		}
+		else if (angleDegs > MAX_2D_CONSTRAINT_ANGLE_DEGS) { 
+		  mAnticlockwiseConstraintDegs = MAX_2D_CONSTRAINT_ANGLE_DEGS; 
+		} else {
+	    mAnticlockwiseConstraintDegs = angleDegs;
+		}
 	}
 	
 	/**

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint3D.java
@@ -69,12 +69,12 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	 * mHingeAntiClockwiseConstraintDegs properties have been set to lower values.</li>
 	 * </ul>
 	 */ 
-	public static enum JointType
+	public enum JointType
 	{
 		BALL,
 		GLOBAL_HINGE,
 		LOCAL_HINGE
-	};	
+	}
 	
 	/** The minimum valid constraint angle for a joint is 0 degrees - this will fully constrain the bone. */
 	public static final float MIN_CONSTRAINT_ANGLE_DEGS = 0.0f;
@@ -173,6 +173,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	 * 
 	 * @param	source	The joint from which to duplicate all properties on this joint.
 	 */
+	@Override
 	public void set(FabrikJoint3D source)
 	{
 		// Copy by value
@@ -276,7 +277,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	 */
 	public float getHingeClockwiseConstraintDegs()
 	{
-		if ( !(mJointType == JointType.BALL) )
+		if ( mJointType != JointType.BALL )
 		{
 			return mHingeClockwiseConstraintDegs;
 		}
@@ -295,7 +296,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	 */
 	public float getHingeAnticlockwiseConstraintDegs()
 	{
-		if ( !(mJointType == JointType.BALL) )
+		if ( mJointType != JointType.BALL )
 		{
 			return mHingeAnticlockwiseConstraintDegs;
 		}
@@ -358,7 +359,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	{
 		FabrikJoint3D.validateConstraintAngleDegs(angleDegs);
 		
-		if ( !(mJointType == JointType.BALL) )
+		if ( mJointType != JointType.BALL )
 		{
 			mHingeClockwiseConstraintDegs = angleDegs;
 		}
@@ -380,7 +381,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	{
 		FabrikJoint3D.validateConstraintAngleDegs(angleDegs);
 		
-		if ( !(mJointType == JointType.BALL) )
+		if ( mJointType != JointType.BALL )
 		{
 			mHingeAnticlockwiseConstraintDegs = angleDegs;
 		}
@@ -402,7 +403,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	{
 		FabrikJoint3D.validateAxis(axis);
 		
-		if ( !(mJointType == JointType.BALL) )
+		if ( mJointType != JointType.BALL )
 		{
 			mRotationAxisUV.set( axis.normalised() );
 		}
@@ -421,7 +422,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	 */
 	public Vec3f getHingeReferenceAxis()
 	{	
-		if ( !(mJointType == JointType.BALL) )
+		if ( mJointType != JointType.BALL )
 		{
 			return mReferenceAxisUV;
 		}
@@ -443,7 +444,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	{
 		FabrikJoint3D.validateAxis(referenceAxis);
 		
-		if ( !(mJointType == JointType.BALL) )
+		if ( mJointType != JointType.BALL )
 		{
 			mReferenceAxisUV.set( referenceAxis.normalised() );
 		}
@@ -462,7 +463,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	 */
 	public Vec3f getHingeRotationAxis()
 	{	
-		if ( !(mJointType == JointType.BALL) )
+		if ( mJointType != JointType.BALL )
 		{
 			return mRotationAxisUV;
 		}
@@ -525,7 +526,7 @@ public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 	
 	private static void validateAxis(Vec3f axis)
 	{
-		if ( !(axis.length() > 0.0f) )
+		if ( axis.length() <= 0.0f )
 		{
 			throw new IllegalArgumentException("Provided axis is illegal - it has a magnitude of zero.");
 		}

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikJoint3D.java
@@ -41,7 +41,7 @@ import au.edu.federation.utils.Vec3f;
  * 
  * @version 0.4.1 - 20/07/2016
  */
-public class FabrikJoint3D
+public class FabrikJoint3D implements FabrikJoint<FabrikJoint3D>
 {
 	// A line separator for the current system running this code
 	private static final String NEW_LINE = System.lineSeparator();

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure.java
@@ -1,0 +1,95 @@
+package au.edu.federation.caliko;
+
+import au.edu.federation.utils.Vectorf;
+
+/**
+ * Structure interface
+ * 
+ * @author jsalvo
+ *
+ */
+@SuppressWarnings("rawtypes")
+public interface FabrikStructure<T extends FabrikChain,V extends Vectorf> {
+	
+  /**
+   * Add a FabrikChain object to a FabrikStructure object.
+   * <p>
+   * Adding a chain using this method adds the chain to the structure, but does not connect it to any existing chain in the structure.
+   * However, all chains in a structure share the same target, and all chains in the structure can be solved for the target location
+   * via a single call to updateTarget on this structure.
+   *  
+   * @param  chain	The chain to add to this structure.
+   **/
+  public void addChain(T chain);
+  
+  /**
+   * Connect a chain to an existing chain in this structure.
+   * <p>
+   * Both chains and bones are are zero indexed.
+   * <p>
+   * If the existingChainNumber or existingBoneNumber specified to connect to does not exist in this structure
+   * then an IllegalArgumentExeception is thrown.
+   * 
+   * @param	newChain			The chain to connect to this structure
+   * @param	existingChainNumber	The index of the chain to connect the new chain to.
+   * @param	existingBoneNumber	The index of the bone to connect the new chain to within the existing chain.
+   */
+  public void connectChain(T newChain, int existingChainNumber, int existingBoneNumber);
+  
+  /**
+   * Connect a chain to an existing chain in this structure.
+   * <p>
+   * Both chains and bones are are zero indexed.
+   * <p>
+   * If the existingChainNumber or existingBoneNumber specified to connect to does not exist in this structure
+   * then an IllegalArgumentExeception is thrown.
+   * 
+   * @param	newChain		The chain to connect to this structure
+   * @param	existingChainNumber	The index of the chain to connect the new chain to.
+   * @param	existingBoneNumber	The index of the bone to connect the new chain to within the existing chain.
+   * @param	boneConnectionPoint	Whether the new chain should connect to the START or END of the specified bone in the specified chain.
+   */
+  public void connectChain(T newChain, int existingChainNumber, int existingBoneNumber, BoneConnectionPoint boneConnectionPoint);	
+  
+  /**
+   * Return a chain which exists in this structure.
+   * <p>
+   * Note: Chains are zero-indexed.
+   * 
+   * @param	chainNumber	The zero-indexed chain in this structure to return.
+   * @return				The desired chain.
+   */
+  public T getChain(int chainNumber);
+  
+  /**
+   * @return The name for this structure
+   */
+  public String getName();
+  
+  /**
+   * Return the number of chains in this structure.
+   * 
+   * @return  The number of chains in this structure.
+   */
+  public int getNumChains();
+  
+  /** 
+   * Set the name of this structure, capped to 100 characters if required.
+   * 
+   * @param name  The name to set.
+   */
+  public void setName(String name);
+  
+  /**
+   * Solve the structure for the given target location.
+   * <p>
+   * All chains in this structure are solved for the given target location EXCEPT those which have embedded targets enabled, which are
+   * solved for the target location embedded in the chain.
+   * <p>
+   * After this method has been executed, the configuration of all IK chains attached to this structure will have been updated.
+   *  
+   * @param   newTargetLocation The location of the target for which we will attempt to solve all chains attached to this structure.
+   */
+  public void solveForTarget(V newTargetLocation);
+
+}

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure2D.java
@@ -30,7 +30,7 @@ public class FabrikStructure2D implements FabrikStructure<FabrikChain2D,Vec2f>
 	private String mName;
 
 	/** The main substance of a FabrikStructure2D is an ArrayList of FabrikChain2D objects. */
-	private List<FabrikChain2D> mChains = new ArrayList<FabrikChain2D>();
+	private List<FabrikChain2D> mChains = new ArrayList<>();
 
 	/** Property to keep track of how many chains exist in this structure. */
 	private int mNumChains = 0;

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure2D.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import au.edu.federation.caliko.FabrikChain2D.BaseboneConstraintType2D;
-import au.edu.federation.caliko.FabrikChain2D.BoneConnectionPoint2D;
 import au.edu.federation.utils.Utils;
 import au.edu.federation.utils.Vec2f;
 
@@ -21,7 +20,7 @@ import au.edu.federation.utils.Vec2f;
  * @author Al Lansley
  * @version 1.0 - 02/08/2016
  **/
-public class FabrikStructure2D
+public class FabrikStructure2D implements FabrikStructure<FabrikChain2D,Vec2f>
 {	
 	private static final Vec2f UP = new Vec2f(0.0f, 1.0f);
 	
@@ -58,6 +57,7 @@ public class FabrikStructure2D
 	 * 
 	 * @param	name	The name to set.
 	 */
+	@Override
 	public void setName(String name) { mName = Utils.getValidatedName(name); }
 	
 	/**
@@ -70,6 +70,7 @@ public class FabrikStructure2D
 	 *  
 	 * @param   newTargetLocation	The location of the target for which we will attempt to solve all chains attached to this structure.
 	 */
+	@Override
 	public void solveForTarget(Vec2f newTargetLocation)
 	{
 		int numChains = mChains.size();
@@ -96,7 +97,7 @@ public class FabrikStructure2D
 				FabrikBone2D hostBone = mChains.get(hostChainNumber).getBone( mChains.get(loop).getConnectedBoneNumber() );
 				
 				// If we're connecting this chain to the start location of the bone in the 'host' chain...
-				if (thisChain.getBoneConnectionPoint() == BoneConnectionPoint2D.START)
+				if (thisChain.getBoneConnectionPoint() == BoneConnectionPoint.START)
 				{
 					// ...set the base location of this bone to be the start location of the bone it's connected to.
 					thisChain.setBaseLocation( hostBone.getStartLocation() );
@@ -178,6 +179,7 @@ public class FabrikStructure2D
 	 * @param  chain	(FabrikChain2D)	The FabrikChain2D to add to this structure.
 	 * @see updateTarget
 	 **/
+	@Override
 	public void addChain(FabrikChain2D chain)
 	{
 		mChains.add(chain);		
@@ -202,7 +204,8 @@ public class FabrikStructure2D
 	 * @param	chainNumber The zero indexed number of the chain to connect the provided chain to.
 	 * @param	boneNumber	The zero indexed number of the bone within the specified chain to connect the provided chain to.
 	 */
-	public void addConnectedChain(FabrikChain2D chain, int chainNumber, int boneNumber)
+	@Override
+	public void connectChain(FabrikChain2D chain, int chainNumber, int boneNumber)
 	{	
 		// Does this chain exist? If not throw an IllegalArgumentException
 		if (chainNumber >= mNumChains)
@@ -225,9 +228,9 @@ public class FabrikStructure2D
 		relativeChain.setConnectedBoneNumber(boneNumber);
 		
 		// Get the connection point so we know to connect at the start or end location of the bone we're connecting to
-		BoneConnectionPoint2D connectionPoint = chain.getBoneConnectionPoint();		
+		BoneConnectionPoint connectionPoint = chain.getBoneConnectionPoint();		
 		Vec2f connectionLocation;
-		if (connectionPoint == BoneConnectionPoint2D.START)
+		if (connectionPoint == BoneConnectionPoint.START)
 		{
 			connectionLocation = mChains.get(chainNumber).getBone(boneNumber).getStartLocation();
 		}
@@ -266,13 +269,14 @@ public class FabrikStructure2D
 	 * @param	boneNumber			The zero-indexed number of bone in the pre-existing chain in this structure that the new chain will attach to.
 	 * @param	boneConnectionPoint	Whether to attach the new chain to the start or end point of the bone we are connecting to.
 	 */
-	public void addConnectedChain(FabrikChain2D chain, int chainNumber, int boneNumber, BoneConnectionPoint2D boneConnectionPoint)
+	@Override
+	public void connectChain(FabrikChain2D chain, int chainNumber, int boneNumber, BoneConnectionPoint boneConnectionPoint)
 	{
 		// Set the bone connection point so we'll connect to the start or the end point of the specified connection bone
 		chain.setBoneConnectionPoint(boneConnectionPoint);
 		
 		// Call the standard addConnectedChain method to perform the connection
-		addConnectedChain(chain, chainNumber, boneNumber);		
+		connectChain(chain, chainNumber, boneNumber);		
 	}
 
 	/**
@@ -280,6 +284,7 @@ public class FabrikStructure2D
 	 * 
 	 * @return	The number of chains in this structure.
 	 */
+	@Override
 	public int getNumChains() { return mNumChains; }
 	
 	/**
@@ -290,6 +295,7 @@ public class FabrikStructure2D
 	 * @param	chainNumber	The zero-indexed chain in this structure to return.
 	 * @return				The desired chain.
 	 */
+	@Override
 	public FabrikChain2D getChain(int chainNumber) { return mChains.get(chainNumber); }
 	
 	/**
@@ -307,6 +313,7 @@ public class FabrikStructure2D
 		mChains.get(0).setFixedBaseMode(mFixedBaseMode);
 	}
 	
+	@Override
 	public String getName() {
 		return this.mName;
 	}

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure2D.java
@@ -150,26 +150,6 @@ public class FabrikStructure2D implements FabrikStructure<FabrikChain2D,Vec2f>
 	} // End of updateTarget method
 
 	/**
-	 * Solve the structure for the given target location.
-	 * <p>
-	 * All chains in this structure are solved for the given target location EXCEPT those which have embedded targets enabled, which are
-	 * solved for the target location embedded in the chain.
-	 * <p>
-	 * After this method has been executed, the configuration of all IK chains attached to this structure will have been updated.
-	 * <p>
-	 * Internally, this method simply constructs a Vec2f from the provided x and y values and calls the Vec2f version of this method.
-	 * 
-	 * @param  targetXLocation	(float)	The horizontal location of the target for which we will solve all chains attached to this structure.
-	 * @param  targetYLocation	(float)	The vertical   location of the target for which we will solve all chains attached to this structure.
-	 **/
-	public void updateTarget(float targetXLocation, float targetYLocation)
-	{
-		// Call our Vec2f version of updateTarget using this constructed target location
-		// Note: This will loop over all chains, attempting to solve each for the same target location
-		solveForTarget( new Vec2f(targetXLocation, targetYLocation) );
-	}
-	
-	/**
 	 * Add a FabrikChain2D object to a FabrikStructure2D object.
 	 * <p>
 	 * Adding a chain using this method adds the chain to the structure, but does not connect it to any existing chain in the structure.

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure2D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure2D.java
@@ -157,7 +157,6 @@ public class FabrikStructure2D implements FabrikStructure<FabrikChain2D,Vec2f>
 	 * via a single call to updateTarget on this structure.
 	 *  
 	 * @param  chain	(FabrikChain2D)	The FabrikChain2D to add to this structure.
-	 * @see updateTarget
 	 **/
 	@Override
 	public void addChain(FabrikChain2D chain)

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure3D.java
@@ -157,25 +157,6 @@ public class FabrikStructure3D implements FabrikStructure<FabrikChain3D,Vec3f>
 	} // End of updateTarget method
 
 	/**
-	 * Solve the structure for the given target location.
-	 * <p>
-	 * All chains in this structure are solved for the given target location EXCEPT those which have embedded targets enabled, which are
-	 * solved for the target location embedded in the chain.
-	 * <p>
-	 * After this method has been executed, the configuration of all IK chains attached to this structure will have been updated.
-	 * 
-	 * @param  targetX	The target x location.
-	 * @param  targetY	The target y location.
-	 * @param  targetZ	The target z location.
-	 **/
-	public void solveForTarget(float targetX, float targetY, float targetZ)
-	{
-		// Call our Vec3f version of updateTarget using a constructed Vec3f target location
-		// Note: This will loop over all chains, attempting to solve each for the same target location
-		solveForTarget( new Vec3f(targetX, targetY, targetZ) );
-	}
-	
-	/**
 	 * Add a FabrikChain3D to this FabrikStructure3D.
 	 * <p>
 	 * In effect, the chain is added to the mChains list of FabrikChain3D objects, and the mNumChains property is incremented.

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure3D.java
@@ -3,7 +3,6 @@ package au.edu.federation.caliko;
 import java.util.ArrayList;
 import java.util.List;
 
-import au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D;
 import au.edu.federation.caliko.FabrikChain3D.BaseboneConstraintType3D;
 import au.edu.federation.utils.Mat3f;
 import au.edu.federation.utils.Utils;
@@ -24,7 +23,7 @@ import au.edu.federation.utils.Vec3f;
  * @author Al Lansley
  * @version 0.4 - 29/12/2015
  **/
-public class FabrikStructure3D
+public class FabrikStructure3D implements FabrikStructure<FabrikChain3D,Vec3f>
 {
 	// ---------- Private Properties ----------
 	
@@ -74,6 +73,7 @@ public class FabrikStructure3D
 	 *  
 	 * @param   newTargetLocation	The location of the target for which we will attempt to solve all chains attached to this structure.
 	 */
+	@Override
 	public void solveForTarget(Vec3f newTargetLocation)
 	{
 		int numChains = mChains.size();
@@ -96,7 +96,7 @@ public class FabrikStructure3D
 				// ... get the host chain and bone which this chain is connected to
 				FabrikChain3D hostChain = mChains.get(connectedChainNumber);
 				FabrikBone3D hostBone   = hostChain.getBone( thisChain.getConnectedBoneNumber() );
-				if (hostBone.getBoneConnectionPoint() == BoneConnectionPoint3D.START) { thisChain.setBaseLocation( hostBone.getStartLocation() ); }
+				if (hostBone.getBoneConnectionPoint() == BoneConnectionPoint.START) { thisChain.setBaseLocation( hostBone.getStartLocation() ); }
 				else                                                                  { thisChain.setBaseLocation( hostBone.getEndLocation()   ); }
 				
 				// Now that we've clamped the base location of this chain to the start or end point of the bone in the chain we are connected to, it's
@@ -187,9 +187,10 @@ public class FabrikStructure3D
 	 * via a single call to updateTarget. 
 	 *  
 	 * @param	chain	(FabrikChain3D)	The FabrikChain3D to add to this structure.
-	 * @see		#connectChain(au.edu.federation.caliko.FabrikChain3D, int, int)
-	 * @see		#connectChain(au.edu.federation.caliko.FabrikChain3D, int, int, au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D)
+	 * @see   #connectChain(FabrikChain3D, int, int)
+	 * @see		#connectChain(FabrikChain3D, int, int, BoneConnectionPoint)
 	 **/
+	@Override
 	public void addChain(FabrikChain3D chain)
 	{
 		mChains.add(chain);		
@@ -221,6 +222,7 @@ public class FabrikStructure3D
 	 * @param	existingChainNumber	The index of the chain to connect the new chain to.
 	 * @param	existingBoneNumber	The index of the bone to connect the new chain to within the existing chain.
 	 */
+	@Override
 	public void connectChain(FabrikChain3D newChain, int existingChainNumber, int existingBoneNumber)
 	{	
 		// Does this chain exist? If not throw an IllegalArgumentException
@@ -246,9 +248,9 @@ public class FabrikStructure3D
 		
 		
 		// Get the connection point so we know to connect at the start or end location of the bone we're connecting to
-		BoneConnectionPoint3D connectionPoint = this.getChain(existingChainNumber).getBone(existingBoneNumber).getBoneConnectionPoint();
+		BoneConnectionPoint connectionPoint = this.getChain(existingChainNumber).getBone(existingBoneNumber).getBoneConnectionPoint();
 		Vec3f connectionLocation;
-		if (connectionPoint == BoneConnectionPoint3D.START)
+		if (connectionPoint == BoneConnectionPoint.START)
 		{
 			connectionLocation = mChains.get(existingChainNumber).getBone(existingBoneNumber).getStartLocation();
 		}
@@ -292,7 +294,8 @@ public class FabrikStructure3D
 	 * @param	existingBoneNumber	The index of the bone to connect the new chain to within the existing chain.
 	 * @param	boneConnectionPoint	Whether the new chain should connect to the START or END of the specified bone in the specified chain.
 	 */
-	public void connectChain(FabrikChain3D newChain, int existingChainNumber, int existingBoneNumber, BoneConnectionPoint3D boneConnectionPoint)
+	@Override
+	public void connectChain(FabrikChain3D newChain, int existingChainNumber, int existingBoneNumber, BoneConnectionPoint boneConnectionPoint)
 	{
 		// Does this chain exist? If not throw an IllegalArgumentException
 		if (existingChainNumber > mNumChains)
@@ -319,7 +322,7 @@ public class FabrikStructure3D
 		// Set the connection point and use it to get the connection location
 		this.getChain(existingChainNumber).getBone(existingBoneNumber).setBoneConnectionPoint(boneConnectionPoint);
 		Vec3f connectionLocation;
-		if (boneConnectionPoint == BoneConnectionPoint3D.START)
+		if (boneConnectionPoint == BoneConnectionPoint.START)
 		{
 			connectionLocation = mChains.get(existingChainNumber).getBone(existingBoneNumber).getStartLocation();
 		}
@@ -355,6 +358,7 @@ public class FabrikStructure3D
 	 *
 	 * @return	The number of chains in this structure.
 	 */
+	@Override
 	public int getNumChains() { return mNumChains; }
 	
 	/**
@@ -366,6 +370,7 @@ public class FabrikStructure3D
 	 * @param	chainNumber	The specified chain from this structure.
 	 * @return	The specified FabrikChain3D from this chain.
 	 */
+	@Override
 	public FabrikChain3D getChain(int chainNumber) { return mChains.get(chainNumber); }
 	
 	/**
@@ -386,8 +391,10 @@ public class FabrikStructure3D
 	 * 
 	 * @param	name	The name to set.
 	 */
+	@Override
 	public void setName(String name) { mName = Utils.getValidatedName(name); }
 	
+	@Override
 	public String getName() {
 		return this.mName;
 	}
@@ -411,7 +418,7 @@ public class FabrikStructure3D
 		{
 			sb.append(mChains.get(loop).toString() );
 		}
-
+ 
 		return sb.toString();
 	}
 

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure3D.java
@@ -29,9 +29,6 @@ public class FabrikStructure3D implements FabrikStructure<FabrikChain3D,Vec3f>
 	
 	private static final String NEW_LINE = System.lineSeparator();
 	
-	/** Max name of structure in characters.*/
-	private static final int MAX_NAME_LENGTH = 100;
-
 	/** The string name of this FabrikStructure3D - can be used for creating Maps, if required. */
 	private String mName;
 	
@@ -41,7 +38,7 @@ public class FabrikStructure3D implements FabrikStructure<FabrikChain3D,Vec3f>
 	 * Each FabrikChain3D in the mChains vector is independent of all others, but shares the same target location as any/all other chains
 	 * which exist in this structure.
 	 */
-	private List<FabrikChain3D> mChains = new ArrayList<FabrikChain3D>();
+	private List<FabrikChain3D> mChains = new ArrayList<>();
 
 	/** Property to keep track of how many chains exist in this structure. */
 	private int mNumChains = 0;
@@ -60,7 +57,7 @@ public class FabrikStructure3D implements FabrikStructure<FabrikChain3D,Vec3f>
 	 */
 	public FabrikStructure3D(String name)
 	{
-		mName = name.length() > MAX_NAME_LENGTH ? name = name.substring(0, MAX_NAME_LENGTH) : name;
+		mName = Utils.getValidatedName(name);
 	}
 
 	/**

--- a/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure3D.java
+++ b/caliko/src/main/java/au/edu/federation/caliko/FabrikStructure3D.java
@@ -3,12 +3,11 @@ package au.edu.federation.caliko;
 import java.util.ArrayList;
 import java.util.List;
 
+import au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D;
 import au.edu.federation.caliko.FabrikChain3D.BaseboneConstraintType3D;
 import au.edu.federation.utils.Mat3f;
 import au.edu.federation.utils.Utils;
-import au.edu.federation.utils.Vec2f;
 import au.edu.federation.utils.Vec3f;
-import static au.edu.federation.caliko.FabrikBone3D.BoneConnectionPoint3D;
 
 /** 
  * A FabrikStructure3D contains one or more FabrikChain3D objects, which we can solve using the FABRIK (Forward And

--- a/caliko/src/main/java/au/edu/federation/utils/Mat4f.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Mat4f.java
@@ -620,13 +620,7 @@ public class Mat4f
 		boolean yDotZOrthogonal = Math.abs( Vec3f.dotProduct(yAxis, zAxis) ) <= epsilon;
 
 		// All three axes are orthogonal? Return true
-		if (xDotYOrthogonal && xDotZOrthogonal && yDotZOrthogonal)
-		{
-			return true;
-		}
-		
-		// One or more axes is not orthogonal? Return false.
-		return false;
+		return (xDotYOrthogonal && xDotZOrthogonal && yDotZOrthogonal);
 	}
 
 	/**
@@ -874,7 +868,7 @@ public class Mat4f
 
 		// Each property of the inverse matrix is multiplied by 1.0f divided by the determinant.
 		// As we cannot divide by zero, we will throw an IllegalArgumentException if the determinant is zero.
-		if (determinant == 0.0f)
+		if (Float.compare(determinant,0.0f)==0)
 		{
 			throw new IllegalArgumentException("Cannot invert a matrix with a determinant of zero.");
 		}
@@ -1342,9 +1336,9 @@ public class Mat4f
 	public static Mat4f createOrthographicProjectionMatrix(float left, float right, float top, float bottom, float near, float far)
 	{
 		// Perform sanity checking to avoid divide by zero errors
-		if (right - left == 0.0f) { throw new IllegalArgumentException("(right - left) cannot be zero."); }
-		if (top - bottom == 0.0f) {	throw new IllegalArgumentException("(top - bottom) cannot be zero."); }		
-		if (far - near   == 0.0f) { throw new IllegalArgumentException("(far - near) cannot be zero.");   }
+		if (Float.compare(right - left,0.0f)==0) { throw new IllegalArgumentException("(right - left) cannot be zero."); }
+		if (Float.compare(top - bottom,0.0f)==0) {	throw new IllegalArgumentException("(top - bottom) cannot be zero."); }		
+		if (Float.compare(far - near,0.0f)==0) { throw new IllegalArgumentException("(far - near) cannot be zero.");   }
 		
 		// Got legal arguments? Construct the orthographic matrix		
 		Mat4f m = new Mat4f();

--- a/caliko/src/main/java/au/edu/federation/utils/Utils.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Utils.java
@@ -11,7 +11,7 @@ import java.util.Random;
  * Version: 0.4
  * Date   : 04/12/2015
  */
-public class Utils
+public final class Utils
 {
 	// Constants to translate values from degrees to radians and vice versa
 	private static final float DEGS_TO_RADS = (float)Math.PI / 180.0f;
@@ -55,6 +55,8 @@ public class Utils
 	
 	/** The maximum length in characters of any names which may be used for bones, chains or structures. */
 	public static final int MAX_NAME_LENGTH = 100;
+	
+	private Utils() {}
 
 	/**
 	 * Set a fixed seed value - call this with any value before starting the inverse kinematics runs to get a repeatable sequence of events.

--- a/caliko/src/main/java/au/edu/federation/utils/Utils.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Utils.java
@@ -19,7 +19,7 @@ public class Utils
 
 	// Define a private static DecimalFormat to be used by our toString() method.
 	// Note: '0' means put a 0 there if it's zero, '#' means omit if zero.
-	public static DecimalFormat df = new DecimalFormat("0.000");
+	public static final DecimalFormat df = new DecimalFormat("0.000");
 	
 	/** Newline character for this system. */
 	public static final String NEW_LINE = System.lineSeparator();
@@ -29,18 +29,18 @@ public class Utils
 	 * <p>
 	 * These colours are neither final nor 'constant', so they can be user modified at runtime if desired.
 	 */
-	public static Colour4f RED       = new Colour4f(1.0f, 0.0f, 0.0f, 1.0f);
-	public static Colour4f GREEN     = new Colour4f(0.0f, 1.0f, 0.0f, 1.0f);
-	public static Colour4f BLUE      = new Colour4f(0.0f, 0.0f, 1.0f, 1.0f);
-	public static Colour4f MID_RED   = new Colour4f(0.6f, 0.0f, 0.0f, 1.0f);
-	public static Colour4f MID_GREEN = new Colour4f(0.0f, 0.6f, 0.0f, 1.0f);
-	public static Colour4f MID_BLUE  = new Colour4f(0.0f, 0.0f, 0.6f, 1.0f);
-	public static Colour4f BLACK     = new Colour4f(0.0f, 0.0f, 0.0f, 1.0f);
-	public static Colour4f GREY      = new Colour4f(0.5f, 0.5f, 0.5f, 1.0f);
-	public static Colour4f WHITE     = new Colour4f(1.0f, 1.0f, 1.0f, 1.0f);
-	public static Colour4f YELLOW    = new Colour4f(1.0f, 1.0f, 0.0f, 1.0f);
-	public static Colour4f CYAN      = new Colour4f(0.0f, 1.0f, 1.0f, 1.0f);
-	public static Colour4f MAGENTA   = new Colour4f(1.0f, 0.0f, 1.0f, 1.0f);
+	public static final Colour4f RED       = new Colour4f(1.0f, 0.0f, 0.0f, 1.0f);
+	public static final Colour4f GREEN     = new Colour4f(0.0f, 1.0f, 0.0f, 1.0f);
+	public static final Colour4f BLUE      = new Colour4f(0.0f, 0.0f, 1.0f, 1.0f);
+	public static final Colour4f MID_RED   = new Colour4f(0.6f, 0.0f, 0.0f, 1.0f);
+	public static final Colour4f MID_GREEN = new Colour4f(0.0f, 0.6f, 0.0f, 1.0f);
+	public static final Colour4f MID_BLUE  = new Colour4f(0.0f, 0.0f, 0.6f, 1.0f);
+	public static final Colour4f BLACK     = new Colour4f(0.0f, 0.0f, 0.0f, 1.0f);
+	public static final Colour4f GREY      = new Colour4f(0.5f, 0.5f, 0.5f, 1.0f);
+	public static final Colour4f WHITE     = new Colour4f(1.0f, 1.0f, 1.0f, 1.0f);
+	public static final Colour4f YELLOW    = new Colour4f(1.0f, 1.0f, 0.0f, 1.0f);
+	public static final Colour4f CYAN      = new Colour4f(0.0f, 1.0f, 1.0f, 1.0f);
+	public static final Colour4f MAGENTA   = new Colour4f(1.0f, 0.0f, 1.0f, 1.0f);
 	
 	/**
 	 * A Random object used to generate random numbers in the randRange methods.
@@ -54,14 +54,14 @@ public class Utils
 	public static Random random = new Random();
 	
 	/** The maximum length in characters of any names which may be used for bones, chains or structures. */
-	public static int MAX_NAME_LENGTH = 100;
+	public static final int MAX_NAME_LENGTH = 100;
 
 	/**
 	 * Set a fixed seed value - call this with any value before starting the inverse kinematics runs to get a repeatable sequence of events.
 	 * 
 	 * @param	seedValue	The seed value to set.
 	 */
-	public void setRandomSeed(int seedValue)
+	public static void setRandomSeed(int seedValue)
 	{
 		random = new Random(seedValue);
 	}
@@ -131,7 +131,9 @@ public class Utils
 	 */ 
 	public static float sign(float value)
 	{
-		if (value >= 0.0f) { return 1.0f; } // Implied else...		
+		if (value >= 0.0f) { 
+		  return 1.0f; 
+		}		
 		return -1.0f;
 	}
 	
@@ -154,7 +156,7 @@ public class Utils
 	public static void validateDirectionUV(Vec2f directionUV)
 	{
 		// Ensure that the magnitude of this direction unit vector is greater than zero
-		if ( !(directionUV.length() > 0.0f) )
+		if ( directionUV.length() <= 0.0f )
 		{
 			throw new IllegalArgumentException("Vec2f direction unit vector cannot be zero.");
 		}
@@ -169,7 +171,7 @@ public class Utils
 	public static void validateDirectionUV(Vec3f directionUV)
 	{
 		// Ensure that the magnitude of this direction unit vector is greater than zero
-		if ( !(directionUV.length() > 0.0f) )
+		if ( directionUV.length() <= 0.0f )
 		{
 			throw new IllegalArgumentException("Vec3f direction unit vector cannot be zero.");
 		}

--- a/caliko/src/main/java/au/edu/federation/utils/Vec2f.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Vec2f.java
@@ -370,7 +370,7 @@ public class Vec2f implements Vectorf<Vec2f>
 	@Override
 	public String toString()
 	{
-		return new String( df.format(x) + ", " + df.format(y) );
+		return df.format(x) + ", " + df.format(y);
 	}
 	
 } // End of Vec2f class

--- a/caliko/src/main/java/au/edu/federation/utils/Vec2f.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Vec2f.java
@@ -9,7 +9,7 @@ import java.text.DecimalFormat;
  *  @author Al Lansley
  *  @version 0.3 - 15/10/2014
  */
-public class Vec2f
+public class Vec2f implements Vectorf<Vec2f>
 {	
 	// Conversion constants to/from degrees and radians
 	private static final float DEGS_TO_RADS = (float)Math.PI / 180.0f;
@@ -50,14 +50,9 @@ public class Vec2f
 	// ---------- Methods ----------
 
 	/**
-	 * Check if this Vec2f is approximately equal to another Vec2f.
-	 * <p>
-	 * If a tolerance of less than zero is provided then an IllegalArgumentException is thrown.
-	 * 
-	 * @param	v			The Vec2f to compare to
-	 * @param   tolerance	The value which both components of each vector must be less than to be considered equal
-	 * @return				A true or false value indicating if the vectors are approximately equal.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean approximatelyEquals(Vec2f v, float tolerance)
 	{	
 		if (tolerance < 0.0f) {	throw new IllegalArgumentException("Equality threshold must be greater than or equal to 0.0f");	}
@@ -65,55 +60,39 @@ public class Vec2f
 	}
 	
 	/**
-	 * Add the provided Vec2f to this Vec2f and return the result in a new Vec2f.
-	 * <p>
-	 * The {@code plus} method does not modify 'this' Vec2f. 
-	 * @param	v	The Vec2f to add.
-	 * @return		A Vec2f which is the result of component-wise addition of this Vec2f and the provided Vec2f.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec2f plus(Vec2f v) { return new Vec2f(x + v.x, y + v.y); }
 
 	/**
-	 * Subtract the provided Vec2f from this Vec2f and return the result in a new Vec2f.
-	 * <p>
-	 * The {@code minus} method does not modify 'this' Vec2f. 
-	 * @param	v	The Vec2f to subtract.
-	 * @return		A Vec2f which is the result of component-wise subtraction of the provided Vec2f from this Vec2f
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec2f minus(Vec2f v) { return new Vec2f(x - v.x, y - v.y); }
 
 	/**
-	 * Component-wise multiply (i.e. scale) this vector by a float and return the result as a new vector.
-	 * <p>
-	 * This Vec2f remains unchanged so you cannot call {@code foo.times(2.0f);} to double it - you must call {@code foo = foo.times(2.0f);}
-	 *
-	 * @param	value	The value to scale this Vec2f by.
-	 * @return		A scaled version of this Vec2f.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec2f times(float value) { return new Vec2f(x * value, y * value); }
 
 	/**
-	 * Component-wise divide this vector by a float and return the result as a new vector.
-	 * <p>
-	 * This Vec2f remains unchanged so you cannot call {@code foo.dividedBy(2.0f);} to halve it - you must call {@code foo = foo.dividedBy(2.0f);}
-	 *
-	 * @param	value	The value to divide this Vec2f by.
-	 * @return		A scaled version of this Vec2f.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec2f dividedBy(float value) { return new Vec2f(x / value, y / value); }
 
 	/**
-	 * Negate this vector and return the result as a new Vec2f. The provided vector remains unchanged.
-	 *
-	 * @return	A negated version of this Vec2f.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec2f negated() { return new Vec2f(-x, -y); }
 
 	/**
-	 * Set the x and y values of a given Vec2f object from a source Vec2f.
-
-	 * @param   source	The source Vec2f from which to copy the values.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public void set(Vec2f source) { x = source.x; y = source.y; }
 
 	/**
@@ -127,19 +106,15 @@ public class Vec2f
 	public void set(float x, float y) { this.x = x; this.y = y; }
 
 	/**
-	 * Return the length (i.e. magnitude) of this vector.
-	 * 
-	 * @return	The length of this vector.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public float length() { return (float)Math.sqrt(x * x + y * y);	}	
 
 	/**
-	 * Normalise and return the provided vector.
-	 * <p>
-	 * If the magnitude of the vector is zero then the original vector is returned.
-	 * 
-	 * @return	A normalised version of this vector.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec2f normalise()
 	{
 		float magnitude = (float)Math.sqrt(this.x * this.x + this.y * this.y);

--- a/caliko/src/main/java/au/edu/federation/utils/Vec3f.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Vec3f.java
@@ -14,7 +14,7 @@ import java.text.DecimalFormat;
  * Date   : 29/12/2015
  */
 
-public class Vec3f
+public class Vec3f implements Vectorf<Vec3f>
 {
 	// ----- Static Properties -----
 	
@@ -76,21 +76,16 @@ public class Vec3f
 	 */
 	public void set(float x, float y, float z) { this.x = x; this.y = y; this.z = z; }
 
-	/** Set this Vec3f to have identical values to a provided source Vec3f.
-	 *
-	 * @param	source	The source vector from which to get the x/y/z properties to set on this vector.
+	/**
+	 * {@inheritDoc}
 	 */
+	@Override
 	public void set(Vec3f source) {	x = source.x; y = source.y; z = source.z; }
 
 	/**
-	 * Check if this Vec3f is approximately equal to another Vec3f.
-	 * <p>
-	 * If a tolerance of less than zero is provided then an IllegalArgumentException is thrown.
-	 * 
-	 * @param	v			The Vec3f to compare to
-	 * @param   tolerance	The value which both components of each vector must be less than to be considered equal
-	 * @return				A true or false value indicating if the vectors are approximately equal.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean approximatelyEquals(Vec3f v, float tolerance)
 	{	
 		if (tolerance < 0.0f)
@@ -163,10 +158,9 @@ public class Vec3f
 	}
 
 	/**
-	 * Return a negated version of this vector - no changes are made to this vector itself.
-	 * 
-	 * @return A negated version of this vector.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec3f negated() { return new Vec3f(-x, -y, -z); }
 	
 	/**
@@ -190,12 +184,9 @@ public class Vec3f
 	}
 	
 	/**
-	 * Normalise and return this vector.
-	 * <p>
-	 * Note: This vector itself is normalised and returned, not a copy / clone.
-	 *
-	 * @return	A normalised version of this vector.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public Vec3f normalise()
 	{
 		// Calculate the magnitude of our vector
@@ -326,10 +317,9 @@ public class Vec3f
 	}
 	
 	/**
-	 * Return the length of this vector.
-	 *
-	 * @return	The length of this vector.
+	 * {@inheritDoc}
 	 */
+	@Override
 	public float length() { return (float)Math.sqrt(x * x + y * y + z * z); }
 	
 	/**
@@ -693,19 +683,15 @@ public class Vec3f
 
 
 	/**
-	 * Return a vector which is the result of adding another vector to this vector. This vector remains unchanged.
-	 * 
-	 * @param	v	The vector to add to this vector
-	 * @return		The result of adding the 'v' vector to this vector.
-	 **/
+	 * {@inheritDoc}
+	 */
+	@Override
 	public Vec3f plus(Vec3f v) { return new Vec3f(this.x + v.x, this.y + v.y, this.z + v.z); }
 
 	/**
-	 * Return a vector which is the result of subtracting the provided vector from this vector. This vector remains unchanged.
-	 * 
-	 * @param	v	The vector to add to this vector
-	 * @return		The result of subtracting the 'v' vector from this vector.
-	 **/
+	 * {@inheritDoc}
+	 */
+	@Override
 	public Vec3f minus(Vec3f v) { return new Vec3f(this.x - v.x, this.y - v.y, this.z - v.z); }
 	
 	/**
@@ -716,11 +702,10 @@ public class Vec3f
 	 **/
 	public Vec3f times(Vec3f v) { return new Vec3f(this.x * v.x, this.y * v.y, this.z * v.z); }
 
-	/** Return a vector which is the result of multiplying this this vector by a scalar value. This vector remains unchanged.
-	 * 
-	 * @param	scale	The amount to scale each component of this vector.
-	 * @return			The result of scaling this vector by the providing argument.
-	 **/
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public Vec3f times(float scale) { return new Vec3f(this.x * scale, this.y * scale, this.z * scale); }
 	
 	/**
@@ -752,14 +737,10 @@ public class Vec3f
 	public static void subtract(Vec3f source, Vec3f other) { source.x -= other.x; source.y -= other.y; source.z -= other.z; }
 
 	/**
-	 * Return a vector which is the result of component-wise division of by the given scalar value. This vector remains unchanged.
-	 * <p>
-	 * Attempting to divide by zero will, unsurprisingly, throw a DivideByZero exception.
-	 * 
-	 * @param	value	The value to divide each component of this vector by.
-	 * @return			A vector which is the result of dividing each component of this vector by the provided argument.
-	 **/
-	public Vec3f divideBy(float value) { return new Vec3f(this.x / value, this.y / value, this.z / value);	}
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Vec3f dividedBy(float value) { return new Vec3f(this.x / value, this.y / value, this.z / value);	}
 	
 	/**
 	 * Return a vector which is the result of projecting this vector onto a plane described by the provided surface normal.

--- a/caliko/src/main/java/au/edu/federation/utils/Vec3f.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Vec3f.java
@@ -129,7 +129,7 @@ public class Vec3f implements Vectorf<Vec3f>
 			throw new IllegalArgumentException("Comparison tolerance cannot be less than zero.");
 		}
 		
-		if ( Math.abs(this.length() - 1.0f) < tolerance)
+		if ( Math.abs(this.length() - value) < tolerance)
 		{
 			return true;
 		}

--- a/caliko/src/main/java/au/edu/federation/utils/Vectorf.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Vectorf.java
@@ -1,0 +1,84 @@
+package au.edu.federation.utils;
+
+/**
+ * Interface for a Vector
+ * 
+ * @author jsalvo
+ *
+ * @param <T>
+ */
+public interface Vectorf<T> {
+	
+	/**
+	 * Check if this vector is approximately equal to another vector.
+	 * <p>
+	 * If a tolerance of less than zero is provided then an IllegalArgumentException is thrown.
+	 * 
+	 * @param	v			The vector to compare to
+	 * @param   tolerance	The value which both components of each vector must be less than to be considered equal
+	 * @return				A true or false value indicating if the vectors are approximately equal.
+	 */
+	boolean approximatelyEquals(T v, float tolerance);
+	
+	/**
+	 * Return a vector which is the result of component-wise division of by the given scalar value. This vector remains unchanged.
+	 * 
+	 * @param	value	The value to divide each component of this vector by.
+	 * @return			A vector which is the result of dividing each component of this vector by the provided argument.
+	 **/	
+	T dividedBy(float value);
+	
+	/**
+	 * Return the length of this vector.
+	 *
+	 * @return	The length of this vector.
+	 */	
+	float length();
+	
+	/**
+	 * Subtract the provided vector from this vector and return the result in a new vector.
+	 * <p>
+	 * The {@code minus} method does not modify 'this' vector. 
+	 * @param	v	The vector to subtract.
+	 * @return		A vector which is the result of component-wise subtraction of the provided Vec2f from this vector
+	 */	
+	T minus(T v);
+	
+	/**
+	 * Return a negated version of this vector - no changes are made to this vector itself.
+	 * 
+	 * @return A negated version of this vector.
+	 */	
+	T negated();
+	
+	/**
+	 * Normalise and return this vector.
+	 * <p>
+	 * Note: This vector itself is normalised and returned, not a copy / clone.
+	 *
+	 * @return	A normalised version of this vector.
+	 */	
+	T normalise();
+	
+	/**
+	 * Return a T which is the result of adding another T to this T. This T remains unchanged.
+	 * 
+	 * @param	v	The T to add to this T
+	 * @return		The result of adding the 'v' vector to this T.
+	 **/	
+	T plus(T v);
+	
+	/** Set this T to have identical values to a provided source Vec3f.
+	 *
+	 * @param	source	The source T from which to get the z properties to set on this T.
+	 */	
+	void set(T source);
+	
+	/** Return a T which is the result of multiplying this this T by a scalar value. This T remains unchanged.
+	 * 
+	 * @param	scale	The amount to scale each component of this vector.
+	 * @return			The result of scaling this T by the providing argument.
+	 **/	
+	T times(float value);
+
+}

--- a/caliko/src/main/java/au/edu/federation/utils/Vectorf.java
+++ b/caliko/src/main/java/au/edu/federation/utils/Vectorf.java
@@ -4,8 +4,6 @@ package au.edu.federation.utils;
  * Interface for a Vector
  * 
  * @author jsalvo
- *
- * @param <T>
  */
 public interface Vectorf<T> {
 	
@@ -76,7 +74,7 @@ public interface Vectorf<T> {
 	
 	/** Return a T which is the result of multiplying this this T by a scalar value. This T remains unchanged.
 	 * 
-	 * @param	scale	The amount to scale each component of this vector.
+	 * @param	value	The amount to scale each component of this vector.
 	 * @return			The result of scaling this T by the providing argument.
 	 **/	
 	T times(float value);

--- a/caliko/src/test/java/au/edu/federation/caliko/ApplicationPerfTest.java
+++ b/caliko/src/test/java/au/edu/federation/caliko/ApplicationPerfTest.java
@@ -1,10 +1,11 @@
 package au.edu.federation.caliko;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import au.edu.federation.utils.Utils;
 import au.edu.federation.utils.Vec3f;
@@ -23,17 +24,15 @@ public class ApplicationPerfTest
 	// Dump results to textfile for import into excel
 	static PrintWriter writer;
 	
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+	
 	@Test
-	public void runTests()
+	public void runTests() throws IOException
 	{	
 		System.out.println("---------- Caliko CPU Performance Analysis ----------");
 		
-		try
-		{
-			writer = new PrintWriter("target/caliko-performance-test.txt", "UTF-8");
-		}
-		catch (FileNotFoundException e)        { e.printStackTrace(); }
-		catch (UnsupportedEncodingException e) { e.printStackTrace(); }		
+		writer = new PrintWriter(folder.newFile("caliko-performance-test.txt"), "UTF-8");
 		
 		// Perform tests
 		int numTests = 3;

--- a/caliko/src/test/java/au/edu/federation/caliko/ApplicationPerfTest.java
+++ b/caliko/src/test/java/au/edu/federation/caliko/ApplicationPerfTest.java
@@ -148,6 +148,9 @@ public class ApplicationPerfTest
 			
 				// Solve for target
 				chain.solveForTarget(target);
+				
+			writer.println(chain.toString());
+			writer.flush();
 			
 			// Get end time
 			endNanos = System.nanoTime();

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <forkCount>0</forkCount>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
**Summary**
- Extract and create interfaces with methods that are common to both 2D and 3D ( e.g. Vectorf, FabrikJoint, FabrikBone, FabrikChain, FabrikStructure, BaseBoneConstraintType )
- Have existing classes implement these new interfaces
- Also extracted out enum BoneConnectionPoint and use this instead of BoneConnectionPoint2D and BoneConnectionPoint3D, since they both have the same values ( START and END )
- Plus lots of Sonar fixes, some low-hanging fixes ( e.g. formatting ), but also some bugfixes in the use of static and equality and comparison on floats

**Build**
Last build result from master ( build#32 ) passed:
https://travis-ci.org/jmsjr/caliko/branches

**Sonar**
Last sonar report remove existing bugs plus reduced the number of vulnerabilities and code smells. The new code smells were considered "new" but they were simply from the existing demo code that were re-factored into separate classes, which Sonar considered "new":
https://sonarqube.com/dashboard?id=au.edu.federation.caliko%3Acaliko-aggregate

