### PR TITLE
Generate two caliko core artifacts ( one for JDK8, another for JDK7 )

### DIFF
--- a/caliko/pom.xml
+++ b/caliko/pom.xml
@@ -40,6 +40,39 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+		    <executions>
+		      <execution>
+            <id>default-1.7</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+		        <configuration>
+              <source>1.7</source>
+              <target>1.7</target>
+		          <outputDirectory>${project.build.outputDirectory}_jdk7</outputDirectory>
+		        </configuration>
+		      </execution>
+		    </executions>
+		  </plugin>
+		  <plugin>
+		    <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>1.7</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk7</classesDirectory>
+              <classifier>jdk7</classifier>
+            </configuration>
+          </execution>
+        </executions>		    
+		  </plugin>               
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>    
       <plugin>


### PR DESCRIPTION
Note: The distribution zip will still only contain the default / JDK8 artifact.
Doing a

`mvn clean install`

shows the following generated:

> [jsalvo@localhost caliko]$ ls -alt caliko/target/*.jar
-rw-rw-r--. 1 jsalvo jsalvo 257519 Jun 10 19:19 caliko/target/caliko-1.3.2-javadoc.jar
-rw-rw-r--. 1 jsalvo jsalvo  83101 Jun 10 19:19 caliko/target/caliko-1.3.2-test-sources.jar
-rw-rw-r--. 1 jsalvo jsalvo 102613 Jun 10 19:19 caliko/target/caliko-1.3.2-sources.jar
-rw-rw-r--. 1 jsalvo jsalvo  76589 Jun 10 19:19 caliko/target/caliko-1.3.2-jdk7.jar
-rw-rw-r--. 1 jsalvo jsalvo  76590 Jun 10 19:19 caliko/target/caliko-1.3.2.jar
[jsalvo@localhost caliko]$ ls -alt ~/.m2/repository/au/edu/federation/caliko/caliko/1.3.2
total 612
-rw-rw-r--. 1 jsalvo jsalvo    282 Jun 10 19:19 _remote.repositories
drwxrwxr-x. 2 jsalvo jsalvo   4096 Jun 10 19:19 .
-rw-rw-r--. 1 jsalvo jsalvo 257519 Jun 10 19:19 caliko-1.3.2-javadoc.jar
-rw-rw-r--. 1 jsalvo jsalvo  76590 Jun 10 19:19 caliko-1.3.2.jar
-rw-rw-r--. 1 jsalvo jsalvo  76589 Jun 10 19:19 caliko-1.3.2-jdk7.jar
-rw-rw-r--. 1 jsalvo jsalvo 102613 Jun 10 19:19 caliko-1.3.2-sources.jar
-rw-rw-r--. 1 jsalvo jsalvo  83101 Jun 10 19:19 caliko-1.3.2-test-sources.jar
-rw-rw-r--. 1 jsalvo jsalvo   2829 Jun 10 18:23 caliko-1.3.2.pom
-rw-rw-r--. 1 jsalvo jsalvo    245 May 27 15:10 caliko-1.3.2.jar.lastUpdated
drwxrwxr-x. 6 jsalvo jsalvo   4096 May 15 23:13 ..

